### PR TITLE
Fix broken SSL

### DIFF
--- a/Off the Record/OTRXMPPManager.m
+++ b/Off the Record/OTRXMPPManager.m
@@ -642,35 +642,9 @@ static const int ddLogLevel = LOG_LEVEL_WARN;
 	}
 	else
 	{
-		// Google does things incorrectly (does not conform to RFC).
-		// Because so many people ask questions about this (assume xmpp framework is broken),
-		// I've explicitly added code that shows how other xmpp clients "do the right thing"
-		// when connecting to a google server (gmail, or google apps for domains).
+		// TLS negotiation *always* use XMPP domain
 		
-		NSString *expectedCertName = nil;
-		
-		NSString *serverDomain = xmppStream.hostName;
-		NSString *virtualDomain = [xmppStream.myJID domain];
-		
-		if ([serverDomain isEqualToString:kOTRGoogleTalkDomain])
-		{
-			if ([virtualDomain isEqualToString:@"gmail.com"])
-			{
-				expectedCertName = virtualDomain;
-			}
-			else
-			{
-				expectedCertName = serverDomain;
-			}
-		}
-		else if (serverDomain == nil)
-		{
-			expectedCertName = virtualDomain;
-		}
-		else
-		{
-			expectedCertName = serverDomain;
-		}
+		NSString *expectedCertName = [xmppStream.myJID domain];
 		
 		if (expectedCertName)
 		{


### PR DESCRIPTION
I don't know why you trying to negotiate TLS with hostname, 100% of other clients and servers uses XMPP domain ;)
It should fix all issues about SSL errors
