### PR TITLE
[Podfile] Turn off CocoaPods Deterministic UUIDs

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,3 +1,6 @@
+# Disable CocoaPods deterministic UUIDs as Pods are not checked in
+ENV["COCOAPODS_DISABLE_DETERMINISTIC_UUIDS"] = "true"
+
 platform :ios, "8.0"
 
 use_frameworks!


### PR DESCRIPTION
re: https://github.com/CocoaPods/CocoaPods/issues/4187

This will turn off [a CocoaPods feature](http://blog.cocoapods.org/CocoaPods-0.38/#deterministic-uuids-by-xcodeproj) which you don't really need that's causing problems for people wanting to compile. 