### PR TITLE
XEP-0357 Support

### DIFF
--- a/ChatSecure/Classes/Controllers/PushController.swift
+++ b/ChatSecure/Classes/Controllers/PushController.swift
@@ -122,8 +122,9 @@ public class PushController: NSObject, OTRPushTLVHandlerDelegate, PushController
         
     }
     
-    
-    
+    public func getPubsubEndpoint(completion:(endpoint:String?,error:NSError?) -> Void) {
+        self.apiClient.getPubsubEndpoint(completion)
+    }
     
     
     public func getNewPushToken(buddyKey:String, completion:(token:Token?,error:NSError?) -> Void) {

--- a/ChatSecure/Classes/Controllers/PushController.swift
+++ b/ChatSecure/Classes/Controllers/PushController.swift
@@ -129,7 +129,7 @@ public class PushController: NSObject, OTRPushTLVHandlerDelegate, PushController
     }
     
     
-    public func getNewPushToken(buddyKey:String, completion:(token:TokenContainer?,error:NSError?) -> Void) {
+    public func getNewPushToken(buddyKey:String?, completion:(token:TokenContainer?,error:NSError?) -> Void) {
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {[weak self] () -> Void in
             guard let tokenContainer = self?.storage.unusedToken() else {
                 self?.updateUnusedTokenStore({[weak self] (success, error) -> Void in
@@ -145,7 +145,9 @@ public class PushController: NSObject, OTRPushTLVHandlerDelegate, PushController
             }
             
             self?.storage.removeUnusedToken(tokenContainer)
-            self?.storage.associateBuddy(tokenContainer, buddyKey: buddyKey)
+            if let buddyKey = buddyKey {
+                self?.storage.associateBuddy(tokenContainer, buddyKey: buddyKey)
+            }
             self?.callbackQueue.addOperationWithBlock({ () -> Void in
                 completion(token: tokenContainer, error: nil)
             })

--- a/ChatSecure/Classes/Controllers/XMPP/OTRXMPPManager.m
+++ b/ChatSecure/Classes/Controllers/XMPP/OTRXMPPManager.m
@@ -255,6 +255,7 @@ NSString *const OTRXMPPLoginErrorKey = @"OTRXMPPLoginErrorKey";
     
     self.xmppCapabilities.autoFetchHashedCapabilities = YES;
     self.xmppCapabilities.autoFetchNonHashedCapabilities = NO;
+    self.xmppCapabilities.autoFetchMyServerCapabilities = YES;
     
     
 	// Activate xmpp modules
@@ -639,7 +640,9 @@ NSString *const OTRXMPPLoginErrorKey = @"OTRXMPPLoginErrorKey";
     
     [self changeLoginStatus:OTRLoginStatusAuthenticated error:nil];
     
-    
+    // Refetch capabilities to check for XEP-0357 support
+    XMPPJID *jid = [XMPPJID jidWithString:[self.JID bare]];
+    [self.xmppCapabilities fetchCapabilitiesForJID:jid];
 }
 
 - (void)xmppStream:(XMPPStream *)sender didNotAuthenticate:(NSXMLElement *)error
@@ -778,6 +781,12 @@ NSString *const OTRXMPPLoginErrorKey = @"OTRXMPPLoginErrorKey";
     */
     
     
+}
+
+#pragma mark XMPPCapabilitiesDelegate
+
+- (void)xmppCapabilities:(XMPPCapabilities *)sender didDiscoverCapabilities:(NSXMLElement *)caps forJID:(XMPPJID *)jid {
+    DDLogVerbose(@"%@: %@\n%@:%@", THIS_FILE, THIS_METHOD, jid, caps);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/ChatSecure/Classes/Model/Yap Storage/Accounts/OTRXMPPAccount.h
+++ b/ChatSecure/Classes/Model/Yap Storage/Accounts/OTRXMPPAccount.h
@@ -16,6 +16,9 @@
 @property (nonatomic, strong) NSString *resource;
 @property (nonatomic) int port;
 
+@property (nonatomic, strong) NSString *pushPubsubEndpoint;
+@property (nonatomic, strong) NSString *pushPubsubNode;
+
 + (int)defaultPort;
 + (NSString *)newResource;
 

--- a/ChatSecure/Classes/Model/Yap Storage/PushContainers.swift
+++ b/ChatSecure/Classes/Model/Yap Storage/PushContainers.swift
@@ -40,7 +40,7 @@ public class DeviceContainer: OTRYapDatabaseObject, YapDatabaseRelationshipNode 
 }
 
 public class TokenContainer: OTRYapDatabaseObject, YapDatabaseRelationshipNode {
-    var pushToken:Token?
+    public var pushToken:Token?
     var date = NSDate()
     var accountKey: String?
     var buddyKey: String?

--- a/ChatSecure/Classes/OTRAppDelegate.m
+++ b/ChatSecure/Classes/OTRAppDelegate.m
@@ -391,20 +391,15 @@
     //[OTRUtilities deleteAllBuddiesAndMessages];
 }
 
-- (void)application:(UIApplication *)application didReceiveRemoteNotification:(nonnull NSDictionary *)userInfo
-{
-    [self.pushController receiveRemoteNotification:userInfo completion:^(OTRBuddy * _Nullable buddy, NSError * _Nullable error) {
-        [application showLocalNotificationForKnockFrom:buddy];
-    }];
-    
-}
-
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler
 {
     [self autoLoginFromBackground:YES];
 
     [self.pushController receiveRemoteNotification:userInfo completion:^(OTRBuddy * _Nullable buddy, NSError * _Nullable error) {
-        [application showLocalNotificationForKnockFrom:buddy];
+        // Only show notification if buddy lookup succeeds
+        if (buddy) {
+            [application showLocalNotificationForKnockFrom:buddy];
+        }
     }];
     
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(20 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{

--- a/ChatSecure/Info.plist
+++ b/ChatSecure/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.2.1</string>
+	<string>3.2.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -35,7 +35,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>31</string>
+	<string>32</string>
 	<key>FacebookAppID</key>
 	<string>447241325394334</string>
 	<key>FacebookDisplayName</key>

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -146,8 +146,10 @@ PODS:
     - XMPPFramework/XEP-0297
     - XMPPFramework/XEP-0308
     - XMPPFramework/XEP-0333
+    - XMPPFramework/XEP-0334
     - XMPPFramework/XEP-0335
     - XMPPFramework/XEP-0352
+    - XMPPFramework/XEP-0357
   - XMPPFramework/BandwidthMonitor (3.6.7):
     - XMPPFramework/Core
   - XMPPFramework/Core (3.6.7):
@@ -242,9 +244,13 @@ PODS:
     - XMPPFramework/Core
   - XMPPFramework/XEP-0333 (3.6.7):
     - XMPPFramework/Core
+  - XMPPFramework/XEP-0334 (3.6.7):
+    - XMPPFramework/Core
   - XMPPFramework/XEP-0335 (3.6.7):
     - XMPPFramework/Core
   - XMPPFramework/XEP-0352 (3.6.7):
+    - XMPPFramework/Core
+  - XMPPFramework/XEP-0357 (3.6.7):
     - XMPPFramework/Core
   - YapDatabase/SQLCipher (2.9):
     - YapDatabase/SQLCipher/Core (= 2.9)
@@ -405,7 +411,7 @@ SPEC CHECKSUMS:
   uservoice-iphone-sdk: 9abf27254c8488d7b72d70fb9b621132d6beebd4
   VTAcknowledgementsViewController: 6056f5f5e5ed995bbf0581bed6ddd29355ca9a80
   XLForm: c9ee7e0f859341279bfd894f9589a9d25c23e4df
-  XMPPFramework: 38ff8dffab0627c46e3903653383f769938f70f6
+  XMPPFramework: 46b686510e4b6ebed5048b906a08934bd8a83aad
   YapDatabase: c00f4197bba2fea17bdbd82c8e8e3f7104b6fa67
   ZXingObjC: bf15b3814f7a105b6d99f47da2333c93a063650a
 


### PR DESCRIPTION
There are still some things that could be improved.

Currently on every stream connection it checks for server support of XEP-0357 and re-registers with a new push token. This is probably too aggressive, but it's the least error prone. This push token is not associated with a buddyKey which may cause issues elsewhere, but seems fine so far.

Another issue is that `mod_cloud_notify` is too aggressive when sending push notifications, and will even send them for typing notifications. Since we display "Someone wants to chat" for every received push that doesn't map to a buddy, it can get a little noisy. We can't control the behavior of other XMPP servers so we should address this in the PubSub node and elsewhere in the client.

We will also want to strip as much content as possible in the PubSub node to avoid leaking extraneous incoming data.