### PR TITLE
Creating an account via nickname ensures JID is unique.

### DIFF
--- a/ChatSecure/Classes/Controllers/Errors.swift
+++ b/ChatSecure/Classes/Controllers/Errors.swift
@@ -8,6 +8,33 @@
 
 import Foundation
 
+public extension NSError {
+    class func XMPPXMLError(error:OTRXMPPXMLError, userInfo:[String:AnyObject]?) -> NSError {
+        return self.chatSecureError(error, userInfo: userInfo)
+    }
+    
+    class func chatSecureError(error:ChatSecureErrorProtocol, userInfo:[String:AnyObject]?) -> NSError {
+        var tempUserInfo:[String:AnyObject] = [NSLocalizedDescriptionKey:error.localizedDescription()]
+        
+        if let additionalDictionary = error.additionalUserInfo() {
+            additionalDictionary.forEach { tempUserInfo.updateValue($1, forKey: $0) }
+        }
+        
+        //Overwrite out userinfo with provided userinfo dicitonary
+        if let additionalDictionary = userInfo {
+            additionalDictionary.forEach { tempUserInfo.updateValue($1, forKey: $0) }
+        }
+        
+        return NSError(domain: kOTRErrorDomain, code: error.code(), userInfo: userInfo)
+    }
+}
+
+public protocol ChatSecureErrorProtocol {
+    func code() -> Int
+    func localizedDescription() -> String
+    func additionalUserInfo() -> [String:AnyObject]?
+}
+
 enum PushError: Int {
     case noPushDevice       = 301
     case invalidURL         = 302
@@ -40,5 +67,33 @@ extension PushError {
     
     func error() -> NSError {
         return NSError(domain: kOTRErrorDomain, code: self.rawValue, userInfo: [NSLocalizedDescriptionKey:self.localizedDescription()])
+    }
+}
+
+
+@objc public enum OTRXMPPXMLError: Int {
+    case UnkownError   = 1000
+    case Conflict      = 1001
+    case NotAcceptable = 1002
+}
+
+extension OTRXMPPXMLError: ChatSecureErrorProtocol {
+    public func code() -> Int {
+        return self.rawValue
+    }
+    
+    public func localizedDescription() -> String {
+        switch self {
+        case .UnkownError:
+            return "Unknown Error"
+        case .Conflict:
+            return "There's a conflict with the username"
+        case .NotAcceptable:
+            return "Not enough information provided"
+        }
+    }
+    
+    public func additionalUserInfo() -> [String : AnyObject]? {
+        return nil
     }
 }

--- a/ChatSecure/Classes/Utilities/OTRPasswordGenerator.h
+++ b/ChatSecure/Classes/Utilities/OTRPasswordGenerator.h
@@ -15,4 +15,7 @@ extern NSUInteger const OTRDefaultPasswordLength;
 /** Length is number of raw random bytes, which is then converted to base64 so expect a longer length. */
 + (NSString *)passwordWithLength:(NSUInteger)length;
 
+/** Length is number of raw random bytes */
++ (NSData *)randomDataWithLength:(NSUInteger)length;
+
 @end

--- a/ChatSecure/Classes/Utilities/OTRPasswordGenerator.m
+++ b/ChatSecure/Classes/Utilities/OTRPasswordGenerator.m
@@ -13,10 +13,15 @@ NSUInteger const OTRDefaultPasswordLength = 100;
 @implementation OTRPasswordGenerator
 
 + (NSString *)passwordWithLength:(NSUInteger)length {
-    NSMutableData* passphraseData = [NSMutableData dataWithLength:length];
-    SecRandomCopyBytes(kSecRandomDefault, length, [passphraseData mutableBytes]);
+    NSData *passphraseData = [self randomDataWithLength:length];
     NSString *passphrase = [passphraseData base64EncodedStringWithOptions:0];
     return passphrase;
+}
+
++ (NSData *)randomDataWithLength:(NSUInteger)length {
+    NSMutableData* passphraseData = [NSMutableData dataWithLength:length];
+    SecRandomCopyBytes(kSecRandomDefault, length, [passphraseData mutableBytes]);
+    return passphraseData;
 }
 
 @end

--- a/ChatSecure/Classes/Utilities/OTRXMPPError.h
+++ b/ChatSecure/Classes/Utilities/OTRXMPPError.h
@@ -18,7 +18,6 @@ extern NSString *const OTRXMPPSSLHostnameKey;
 
 typedef NS_ENUM(NSUInteger, OTRXMPPErrorCode) {
     OTRXMPPUnsupportedAction,
-    OTRXMPPXMLError,
     OTRXMPPSSLError,
     OTRXMPPDomainError,
     OTRXMPPTorError

--- a/ChatSecure/Classes/View Controllers/Login View Controllers/OTRBaseLoginViewController.m
+++ b/ChatSecure/Classes/View Controllers/Login View Controllers/OTRBaseLoginViewController.m
@@ -185,7 +185,19 @@
 
 - (void)handleXMPPError:(NSError *)error
 {
-    [self showAlertViewWithTitle:ERROR_STRING message:XMPP_FAIL_STRING error:error];
+    if (error.code == OTRXMPPXMLErrorConflict) {
+        //Caught the conflict error before there's any alert displayed on the screen
+        //Create a new nickname with a random hex value at the end
+        NSString *uniqueString = [[OTRPasswordGenerator randomDataWithLength:2] hexString];
+        XLFormRowDescriptor* nicknameRow = [self.form formRowWithTag:kOTRXLFormNicknameTextFieldTag];
+        NSString *value = [nicknameRow value];
+        NSString *newValue = [NSString stringWithFormat:@"%@.%@",value,uniqueString];
+        nicknameRow.value = newValue;
+        [self loginButtonPressed:nil];
+    } else {
+        [self showAlertViewWithTitle:ERROR_STRING message:XMPP_FAIL_STRING error:error];
+    }
+    
 }
 
 - (void)showAlertViewWithTitle:(NSString *)title message:(NSString *)message error:(NSError *)error


### PR DESCRIPTION
First it tries to create a JID using the desired nickname. If the
server responds that there is a conflict it appends two random byes in
hex to the end until it is no longer a conflict.