### PR TITLE
Allow username with IP address

### DIFF
--- a/ChatSecure/Classes/View Controllers/Login View Controllers/OTRXLFormCreator.m
+++ b/ChatSecure/Classes/View Controllers/Login View Controllers/OTRXLFormCreator.m
@@ -182,7 +182,7 @@ NSString *const kOTRXLFormUseTorTag               = @"kOTRXLFormUseTorTag";
     XLFormRowDescriptor *usernameDescriptor = [self textfieldFormDescriptorType:XLFormRowDescriptorTypeEmail withTag:kOTRXLFormUsernameTextFieldTag title:USERNAME_STRING placeHolder:XMPP_USERNAME_EXAMPLE_STRING value:value];
     usernameDescriptor.value = value;
     usernameDescriptor.required = YES;
-    [usernameDescriptor addValidator:[XLFormValidator emailValidatorLong]];
+    [usernameDescriptor addValidator:[[OTRUsernameValidator alloc] init]];
     return usernameDescriptor;
 }
 


### PR DESCRIPTION
In response to Issues #550 and #539, change Validator in jidTextFieldRowDescriptorWithValue to OTRUsernameValidator instead of emailValidator. An alternate solution might be to get rid of the jidTextFieldRowDescriptorWithValue method or just call the usernameTextFieldRowDescriptorWithValue method from the Username field in Add Existing User