### PR TITLE
Move OTR session refresh to end of updateViewWithKey:collection:

### DIFF
--- a/ChatSecure/Classes/View Controllers/OTRMessagesViewController.m
+++ b/ChatSecure/Classes/View Controllers/OTRMessagesViewController.m
@@ -412,10 +412,6 @@ typedef NS_ENUM(int, OTRDropDownType) {
         BOOL previousState = self.state.isThreadOnline;
         self.state.isThreadOnline = buddy.status != OTRThreadStatusOffline;
         
-        // Auto-inititate OTR when contact comes online
-        if (!previousState && self.state.isThreadOnline) {
-            [[OTRProtocolManager sharedInstance].encryptionManager maybeRefreshOTRSessionForBuddyKey:key collection:collection];
-        }
         [self didUpdateState];
         
         //Update Buddy knock status
@@ -434,6 +430,11 @@ typedef NS_ENUM(int, OTRDropDownType) {
         });
         
         [self refreshTitleView:[self titleView]];
+
+        // Auto-inititate OTR when contact comes online
+        if (!previousState && self.state.isThreadOnline) {
+            [[OTRProtocolManager sharedInstance].encryptionManager maybeRefreshOTRSessionForBuddyKey:key collection:collection];
+        }
     }
     
     [self tryToMarkAllMessagesAsRead];


### PR DESCRIPTION
Seems like there is some kind of race condition, so that if we enter a
chat with a friend that is in "pending approval" state - once this
friend accepts us a session is established but the UI is not correctly
updated (or alternatively a session is never created). This seems to
fix that. Zom issue #313.