### PR TITLE
Add migration type link and send it in migration message

### DIFF
--- a/ChatSecure/Classes/Categories/NSURL+ChatSecure.m
+++ b/ChatSecure/Classes/Categories/NSURL+ChatSecure.m
@@ -110,8 +110,11 @@
     NSArray *components = [urlString componentsSeparatedByString:@"/i/#"];
     
     if (components.count != 2) {
-        completion(nil, nil);
-        return;
+        components = [urlString componentsSeparatedByString:@"/m/#"]; // try migration link
+        if (components.count != 2) {
+            completion(nil, nil);
+            return;
+        }
     }
     
     NSString *base64String = components[1];
@@ -148,9 +151,9 @@
 }
 
 
-/** Checks if URL contains '/i/#' for the invite links of this style: https://chatsecure.org/i/#YWhkdmRqZ... */
+/** Checks if URL contains '/i/#' for the invite links of this style: https://chatsecure.org/i/#YWhkdmRqZ... (or '/m/#' for migration type links) */
 - (BOOL) otr_isInviteLink {
-    return [self.absoluteString containsString:@"/i/#"];
+    return [self.absoluteString containsString:@"/i/#"] || [self.absoluteString containsString:@"/m/#"];
 }
 
 /** This will give a user a prompt before calling openURL */


### PR DESCRIPTION
@chrisballinger I could not easily append m=1, changing to /m/ was easier (because how the url is encoded/decoded). Let me know if this will work?