### PR TITLE
Do not close stream when in background

### DIFF
--- a/ChatSecure/Classes/Controllers/OTRProtocol.h
+++ b/ChatSecure/Classes/Controllers/OTRProtocol.h
@@ -31,6 +31,7 @@ typedef NS_ENUM(int, OTRProtocolType) {
 
 typedef NS_ENUM(NSInteger, OTRProtocolConnectionStatus) {
     OTRProtocolConnectionStatusDisconnected,
+    OTRProtocolConnectionStatusDisconnecting,
     OTRProtocolConnectionStatusConnected,
     OTRProtocolConnectionStatusConnecting
 };

--- a/ChatSecure/Classes/Controllers/XMPP/OTRXMPPManager.h
+++ b/ChatSecure/Classes/Controllers/XMPP/OTRXMPPManager.h
@@ -35,7 +35,7 @@
 @class XMPPPushModule, ServerCheck, FileTransferManager;
 
 NS_ASSUME_NONNULL_BEGIN
-@interface OTRXMPPManager : NSObject <XMPPRosterDelegate, NSFetchedResultsControllerDelegate, OTRProtocol>
+@interface OTRXMPPManager : NSObject <XMPPRosterDelegate, XMPPStreamDelegate, NSFetchedResultsControllerDelegate, OTRProtocol>
 
 @property (nonatomic, strong, readonly) OTRXMPPAccount *account;
 

--- a/ChatSecure/Classes/View Controllers/AccountDetailViewController.swift
+++ b/ChatSecure/Classes/View Controllers/AccountDetailViewController.swift
@@ -307,7 +307,8 @@ open class AccountDetailViewController: UIViewController, UITableViewDelegate, U
         case .connecting:
             cell.button.setTitle("\(CONNECTING_STRING())...", for: .normal)
             cell.button.isEnabled = false
-        case .disconnected:
+        case .disconnecting,
+             .disconnected:
             cell.button.setTitle(LOGIN_STRING(), for: .normal)
             cell.buttonAction = { [weak self] (cell, sender) in
                 guard let strongSelf = self else { return }


### PR DESCRIPTION
Keeping the stream alive when going to background was broken in commit 158bb562d4e32f241674bbb453043be939e08c6b, where `[xmppStream disconnect]` was replaced with `disconnectAfterSending`. These two methods have different semantics: `disconnectAfterSending` sends `</stream>` before closing the socket, and `disconnect` does not.

This solution is not very elegant, but works and does not require changing XMPPFramework.