### PR TITLE
Revert to old isPendingApproval implementation

### DIFF
--- a/ChatSecure/Classes/Controllers/XMPP/OTRYapDatabaseRosterStorage.m
+++ b/ChatSecure/Classes/Controllers/XMPP/OTRYapDatabaseRosterStorage.m
@@ -128,16 +128,18 @@ typedef NS_ENUM(NSInteger, OTRSubscriptionAttribute) {
 
 -(BOOL)isPendingApproval:(NSXMLElement *)item
 {
+    NSString *ask = [item attributeStringValueForName:@"ask"];
+    if ([ask isEqualToString:@"subscribe"]) {
+        return YES;
+    }
+    
     OTRSubscriptionAttribute subscriptionAttribute = [self subscriptionAttribute:item];
     
     // If you are subscribed to or are mutually subscribed then you are not pending approval.
-    if (subscriptionAttribute == OTRSubscriptionAttributeNone || subscriptionAttribute == OTRSubscriptionAttributeFrom) {
-        NSString *ask = [item attributeStringValueForName:@"ask"];
-        if ([ask isEqualToString:@"subscribe"]) {
-            return YES;
-        }
+    if (subscriptionAttribute == OTRSubscriptionAttributeTo || subscriptionAttribute == OTRSubscriptionAttributeBoth) {
+        return NO;
     }
-    return NO;
+    return YES;
 }
 
 /** Buddy can be nil, which indicates a new buddy should be saved. */


### PR DESCRIPTION
This reverts the change that breaks the two-way subscription handling.

Without having looked at it too deeply I think it really strange that this implementation differs logically from those in XMPPUserCoreDataStorageObject.m and XMPPUserMemoryStorageObject.m. Why should they not be the same?