### PR TITLE
Invalidate stored size info and "one message cache"

### DIFF
--- a/ChatSecure/Classes/View Controllers/OTRMessagesViewController.m
+++ b/ChatSecure/Classes/View Controllers/OTRMessagesViewController.m
@@ -2001,8 +2001,17 @@ heightForCellBottomLabelAtIndexPath:(NSIndexPath *)indexPath
             [alert addAction:obj];
         }];
         [alert addAction:[self cancleAction]];
+        
+        // Get the anchor
         alert.popoverPresentationController.sourceView = self.view;
         alert.popoverPresentationController.sourceRect = self.view.bounds;
+        UICollectionViewCell *cell = [collectionView cellForItemAtIndexPath:indexPath];
+        if ([cell isKindOfClass:[JSQMessagesCollectionViewCell class]]) {
+            UIView *cellContainterView = ((JSQMessagesCollectionViewCell *)cell).messageBubbleContainerView;
+            alert.popoverPresentationController.sourceRect = cellContainterView.bounds;
+            alert.popoverPresentationController.sourceView = cellContainterView;
+        }
+
         [self presentViewController:alert animated:YES completion:nil];
     }
 }


### PR DESCRIPTION
This message cache thingy "currentMessageIndex" could have caused a looooot of strange issues, since it was never reset in "onReceivedChanges". This meant we could have hit a different object from the one we thought (the currentMessage) in a lot of places!