### PR TITLE
More reliable disconnects

### DIFF
--- a/ChatSecure/Classes/Controllers/OTRProtocol.h
+++ b/ChatSecure/Classes/Controllers/OTRProtocol.h
@@ -49,7 +49,7 @@ typedef NS_ENUM(NSInteger, OTRLoginStatus) {
 NS_ASSUME_NONNULL_BEGIN
 @protocol OTRProtocol <NSObject>
 
-@property (nonatomic, readonly) OTRProtocolConnectionStatus connectionStatus;
+@property (atomic, readonly) OTRProtocolConnectionStatus connectionStatus;
 
 /** Send a message immediately. Bypasses (and used by) the message queue. */
 - (void) sendMessage:(OTROutgoingMessage*)message;

--- a/ChatSecure/Classes/Controllers/OTRProtocolManager.h
+++ b/ChatSecure/Classes/Controllers/OTRProtocolManager.h
@@ -53,7 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)loginAccounts:(NSArray<OTRAccount*> *)accounts;
 - (void)goAwayForAllAccounts;
 - (void)disconnectAllAccounts;
-- (void)disconnectAllAccountsSocketOnly:(BOOL)socketOnly andWait:(BOOL)wait;
+- (void)disconnectAllAccountsSocketOnly:(BOOL)socketOnly timeout:(NSTimeInterval)timeout completionBlock:(nullable void (^)())completionBlock;
 
 - (void)sendMessage:(OTROutgoingMessage *)message;
 

--- a/ChatSecure/Classes/Controllers/OTRProtocolManager.h
+++ b/ChatSecure/Classes/Controllers/OTRProtocolManager.h
@@ -53,7 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)loginAccounts:(NSArray<OTRAccount*> *)accounts;
 - (void)goAwayForAllAccounts;
 - (void)disconnectAllAccounts;
-- (void)disconnectAllAccountsSocketOnly:(BOOL)socketOnly;
+- (void)disconnectAllAccountsSocketOnly:(BOOL)socketOnly andWait:(BOOL)wait;
 
 - (void)sendMessage:(OTROutgoingMessage *)message;
 

--- a/ChatSecure/Classes/Controllers/XMPP/OTRXMPPManager.m
+++ b/ChatSecure/Classes/Controllers/XMPP/OTRXMPPManager.m
@@ -519,7 +519,7 @@ typedef NS_ENUM(NSInteger, XMPPClientState) {
 - (void) disconnectSocketOnly:(BOOL)socketOnly {
     DDLogVerbose(@"%@: %@ %d", THIS_FILE, THIS_METHOD, socketOnly);
     if (socketOnly) {
-        if (self.connectionStatus != OTRProtocolConnectionStatusDisconnecting) {
+        if (self.connectionStatus == OTRProtocolConnectionStatusConnecting || self.connectionStatus == OTRProtocolConnectionStatusConnected) {
             self.connectionStatus = OTRProtocolConnectionStatusDisconnecting;
             [self goAway];
         }

--- a/ChatSecure/Classes/Controllers/XMPP/OTRXMPPManager_Private.h
+++ b/ChatSecure/Classes/Controllers/XMPP/OTRXMPPManager_Private.h
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readwrite) BOOL isRegisteringNewAccount;
 @property (nonatomic, readwrite) BOOL userInitiatedConnection;
 @property (nonatomic, readwrite) OTRLoginStatus loginStatus;
-@property (nonatomic, readwrite) OTRProtocolConnectionStatus connectionStatus;
+@property (atomic, readwrite) OTRProtocolConnectionStatus connectionStatus;
 
 - (void)setupStream;
 - (void)teardownStream;

--- a/ChatSecure/Classes/OTRAppDelegate.m
+++ b/ChatSecure/Classes/OTRAppDelegate.m
@@ -311,14 +311,15 @@
     
     self.backgroundTask = [application beginBackgroundTaskWithExpirationHandler: ^{
         DDLogInfo(@"Background task expired, disconnecting all accounts. Remaining: %f", application.backgroundTimeRemaining);
-        [[OTRProtocolManager sharedInstance] disconnectAllAccountsSocketOnly:YES andWait:YES];
         if (self.backgroundTimer)
         {
             [self.backgroundTimer invalidate];
             self.backgroundTimer = nil;
         }
-        [application endBackgroundTask:self.backgroundTask];
-        self.backgroundTask = UIBackgroundTaskInvalid;
+        [[OTRProtocolManager sharedInstance] disconnectAllAccountsSocketOnly:YES timeout:application.backgroundTimeRemaining - .5 completionBlock:^{
+            [application endBackgroundTask:self.backgroundTask];
+            self.backgroundTask = UIBackgroundTaskInvalid;
+        }];
     }];
     
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -403,16 +404,18 @@
 }
 
 - (void) fetchTimerUpdate:(NSTimer*)timer {
-    [[OTRProtocolManager sharedInstance] disconnectAllAccountsSocketOnly:YES andWait:YES];
-    NSDictionary *userInfo = timer.userInfo;
-    void (^completion)(UIBackgroundFetchResult) = [userInfo objectForKey:@"completion"];
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        [UIApplication.sharedApplication removeExtraForegroundNotifications];
-        // We should probbaly return accurate fetch results
-        if (completion) {
-            completion(UIBackgroundFetchResultNewData);
-        }
-    });
+    void (^completion)(UIBackgroundFetchResult) = timer.userInfo[@"completion"];
+    NSTimeInterval timeout = [[UIApplication sharedApplication] backgroundTimeRemaining] - .5;
+
+    [[OTRProtocolManager sharedInstance] disconnectAllAccountsSocketOnly:YES timeout:timeout completionBlock:^{
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [UIApplication.sharedApplication removeExtraForegroundNotifications];
+            // We should probably return accurate fetch results
+            if (completion) {
+                completion(UIBackgroundFetchResultNewData);
+            }
+        });
+    }];
     self.fetchTimer = nil;
 }
 

--- a/ChatSecure/Classes/OTRAppDelegate.m
+++ b/ChatSecure/Classes/OTRAppDelegate.m
@@ -310,17 +310,15 @@
     }];
     
     self.backgroundTask = [application beginBackgroundTaskWithExpirationHandler: ^{
-        dispatch_async(dispatch_get_main_queue(), ^{
-            DDLogInfo(@"Background task expired, disconnecting all accounts. Remaining: %f", application.backgroundTimeRemaining);
-            [[OTRProtocolManager sharedInstance] disconnectAllAccountsSocketOnly:YES];
-            if (self.backgroundTimer)
-            {
-                [self.backgroundTimer invalidate];
-                self.backgroundTimer = nil;
-            }
-            [application endBackgroundTask:self.backgroundTask];
-            self.backgroundTask = UIBackgroundTaskInvalid;
-        });
+        DDLogInfo(@"Background task expired, disconnecting all accounts. Remaining: %f", application.backgroundTimeRemaining);
+        [[OTRProtocolManager sharedInstance] disconnectAllAccountsSocketOnly:YES andWait:YES];
+        if (self.backgroundTimer)
+        {
+            [self.backgroundTimer invalidate];
+            self.backgroundTimer = nil;
+        }
+        [application endBackgroundTask:self.backgroundTask];
+        self.backgroundTask = UIBackgroundTaskInvalid;
     }];
     
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -405,7 +403,7 @@
 }
 
 - (void) fetchTimerUpdate:(NSTimer*)timer {
-    [[OTRProtocolManager sharedInstance] disconnectAllAccountsSocketOnly:YES];
+    [[OTRProtocolManager sharedInstance] disconnectAllAccountsSocketOnly:YES andWait:YES];
     NSDictionary *userInfo = timer.userInfo;
     void (^completion)(UIBackgroundFetchResult) = [userInfo objectForKey:@"completion"];
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{


### PR DESCRIPTION
Disconnect from the background tasks does not always work correctly, because the background task terminates too early. As a result, on the next attempt to connect we're sometimes unable to resume the session.