### PR TITLE
Occupant deduplication

### DIFF
--- a/ChatSecure/Classes/Controllers/OTRProtocolManager.m
+++ b/ChatSecure/Classes/Controllers/OTRProtocolManager.m
@@ -108,13 +108,13 @@
     if (!account.uniqueId) { return nil; }
     id <OTRProtocol> protocol = nil;
     @synchronized (self) {
-         protocol = [self.protocolManagers objectForKey:account.uniqueId];
-    }
-    if(!protocol)
-    {
-        protocol = [[[account protocolClass] alloc] initWithAccount:account];
-        if (protocol && account.uniqueId) {
-            [self addProtocol:protocol forAccount:account];
+        protocol = [self.protocolManagers objectForKey:account.uniqueId];
+        if(!protocol)
+        {
+            protocol = [[[account protocolClass] alloc] initWithAccount:account];
+            if (protocol && account.uniqueId) {
+                [self addProtocol:protocol forAccount:account];
+            }
         }
     }
     return protocol;

--- a/ChatSecure/Classes/Controllers/XMPP/OTRXMPPManager.m
+++ b/ChatSecure/Classes/Controllers/XMPP/OTRXMPPManager.m
@@ -821,13 +821,16 @@ typedef NS_ENUM(NSInteger, XMPPClientState) {
     
     //Reset buddy info to offline
     __block NSArray<OTRXMPPBuddy*> *allBuddies = nil;
+    __block NSArray<OTRXMPPRoom*> *allRooms = nil;
     [self.databaseConnection asyncReadWithBlock:^(YapDatabaseReadTransaction *transaction) {
         allBuddies = [self.account allBuddiesWithTransaction:transaction];
+        allRooms = [self.account allRoomsWithTransaction:transaction];
     } completionBlock:^{
         // We don't need to save in here because we're using OTRBuddyCache in memory storage
         if (!self.streamManagementDelegate.streamManagementEnabled) {
             [OTRBuddyCache.shared purgeAllPropertiesForBuddies:allBuddies];
         }
+        [OTRBuddyCache.shared purgeAllPropertiesForRooms:allRooms];
     }];
 }
 

--- a/ChatSecure/Classes/Controllers/XMPP/OTRXMPPRoomManager.m
+++ b/ChatSecure/Classes/Controllers/XMPP/OTRXMPPRoomManager.m
@@ -158,6 +158,7 @@
         
         OTRXMPPRoomOccupant *occupant = [transaction objectForKey:edge.sourceKey inCollection:edge.sourceCollection];
         occupant.role = RoomOccupantRoleNone;
+        occupant.jids = nil;
         [occupant saveWithTransaction:transaction];
     }];
 }
@@ -368,6 +369,16 @@
     [self xmppRoom:room addOccupantItems:items];
 }
 
+- (void) xmppRoom:(XMPPRoom *)room didFetchAdminsList:(NSArray<NSXMLElement*> *)items {
+    DDLogInfo(@"Fetched admins list: %@", items);
+    [self xmppRoom:room addOccupantItems:items];
+}
+
+- (void) xmppRoom:(XMPPRoom *)room didFetchOwnersList:(NSArray<NSXMLElement*> *)items {
+    DDLogInfo(@"Fetched owners list: %@", items);
+    [self xmppRoom:room addOccupantItems:items];
+}
+
 - (void)xmppRoom:(XMPPRoom *)room didFetchModeratorsList:(NSArray *)items {
     DDLogInfo(@"Fetched moderators list: %@", items);
     [self xmppRoom:room addOccupantItems:items];
@@ -426,6 +437,8 @@
     // Fetch member list. Ideally this would be done after the invites above have been sent to the network, but the messages pass all kinds of async delegates before they are actually sent, so unfortunately we can't wait for that.
     [self performBlockAsync:^{
             [sender fetchMembersList];
+            [sender fetchAdminsList];
+            [sender fetchOwnersList];
             [sender fetchModeratorsList];
     }];
 }
@@ -440,9 +453,11 @@
         // Fetch member list
         [self performBlockAsync:^{
             [sender fetchMembersList];
+            [sender fetchAdminsList];
+            [sender fetchOwnersList];
             [sender fetchModeratorsList];
+            [self fetchHistoryFor:sender];
         }];
-        [self fetchHistoryFor:sender];
     }
 }
 

--- a/ChatSecure/Classes/Controllers/XMPP/Storage/RoomStorage.swift
+++ b/ChatSecure/Classes/Controllers/XMPP/Storage/RoomStorage.swift
@@ -148,9 +148,9 @@ extension RoomStorage: XMPPRoomStorage {
             let role = item.attributeStringValue(forName: "role") ?? ""
             let affiliation = item.attributeStringValue(forName: "affiliation") ?? ""
             if presence.presenceType == .unavailable {
-                occupant.removeJid(presenceJID.full)
+                occupant.removeJid(presenceJID)
             } else {
-                occupant.addJid(presenceJID.full)
+                occupant.addJid(presenceJID)
             }
             occupant.roomName = presenceJID.resource
             occupant.role = RoomOccupantRole(stringValue: role)

--- a/ChatSecure/Classes/Controllers/XMPP/Storage/RoomStorage.swift
+++ b/ChatSecure/Classes/Controllers/XMPP/Storage/RoomStorage.swift
@@ -90,9 +90,19 @@ import YapDatabase
             let message = OTRXMPPRoomMessage(message: xmppMessage, delayed: delayed, room: room)
             message.originId = originId
             message.stanzaId = stanzaId
-            
-            if let sender = message.senderJID, let senderJid = XMPPJID(string: sender), let roomJid = room.roomJID, let occupant = OTRXMPPRoomOccupant.occupant(jid: senderJid, realJID: nil, roomJID: roomJid, accountId: account.uniqueId, createIfNeeded: false, transaction: transaction) {
-                message.buddyUniqueId = occupant.buddyUniqueId
+
+            // Try to find buddy of sender. We might get an muc#user item element from where we can pull the real jid of the sender, else we try by message.senderJID.
+            if let x = xmppMessage.element(forName: "x", xmlns: XMPPMUCUserNamespace), let item = x.element(forName: "item"), let jidString = item.attribute(forName: "jid")?.stringValue, let jid = XMPPJID(string: jidString) {
+                if let buddy = OTRXMPPBuddy.fetchBuddy(jid: jid, accountUniqueId: account.uniqueId, transaction: transaction) {
+                    message.buddyUniqueId = buddy.uniqueId
+                }
+                // Is this from us?
+                if let accountJid = account.bareJID, jid.bareJID.isEqual(to: accountJid) {
+                    message.state = .sent
+                }
+            }
+            if message.buddyUniqueId == nil, let senderJidString = message.senderJID, let senderJid = XMPPJID(string: senderJidString), let roomJid = room.roomJID, let occupant = OTRXMPPRoomOccupant.occupant(jid: senderJid, realJID: senderJid, roomJID: roomJid, accountId: account.uniqueId, createIfNeeded: false, transaction: transaction), let buddy = occupant.buddy(with: transaction) {
+                message.buddyUniqueId = buddy.uniqueId
             }
             
             room.lastRoomMessageId = message.uniqueId
@@ -129,7 +139,7 @@ extension RoomStorage: XMPPRoomStorage {
             // Will be nil in anonymous rooms (and semi-anonymous rooms if we are not moderators)
             var buddyJID: XMPPJID? = nil
             if let buddyJidString = item.attributeStringValue(forName: "jid") {
-                buddyJID = XMPPJID(string: buddyJidString)
+                buddyJID = XMPPJID(string: buddyJidString)?.bareJID
             }
             guard let occupant = OTRXMPPRoomOccupant.occupant(jid: presenceJID, realJID: buddyJID, roomJID: room.roomJID, accountId: accountId, createIfNeeded: true, transaction: transaction)?.copyAsSelf() else {
                 DDLogWarn("Could not create room occupant")
@@ -138,13 +148,9 @@ extension RoomStorage: XMPPRoomStorage {
             let role = item.attributeStringValue(forName: "role") ?? ""
             let affiliation = item.attributeStringValue(forName: "affiliation") ?? ""
             if presence.presenceType == .unavailable {
-                occupant.available = false
+                occupant.removeJid(presenceJID.full)
             } else {
-                occupant.available = true
-            }
-            occupant.jid = presenceJID.full
-            if buddyJID != nil {
-                occupant.realJID = buddyJID?.bare
+                occupant.addJid(presenceJID.full)
             }
             occupant.roomName = presenceJID.resource
             occupant.role = RoomOccupantRole(stringValue: role)

--- a/ChatSecure/Classes/Controllers/XMPP/Storage/RoomStorage.swift
+++ b/ChatSecure/Classes/Controllers/XMPP/Storage/RoomStorage.swift
@@ -103,6 +103,10 @@ import YapDatabase
             }
             if message.buddyUniqueId == nil, let senderJidString = message.senderJID, let senderJid = XMPPJID(string: senderJidString), let roomJid = room.roomJID, let occupant = OTRXMPPRoomOccupant.occupant(jid: senderJid, realJID: senderJid, roomJID: roomJid, accountId: account.uniqueId, createIfNeeded: false, transaction: transaction), let buddy = occupant.buddy(with: transaction) {
                 message.buddyUniqueId = buddy.uniqueId
+                // Is this from us?
+                if let accountJid = account.bareJID, let realJid = occupant.realJID, realJid.isEqual(accountJid) {
+                    message.state = .sent
+                }
             }
             
             room.lastRoomMessageId = message.uniqueId

--- a/ChatSecure/Classes/Controllers/YapDatabase+ChatSecure.swift
+++ b/ChatSecure/Classes/Controllers/YapDatabase+ChatSecure.swift
@@ -58,11 +58,11 @@ public extension YapDatabase {
                 }
             }
             
-            guard let name1 = (object1 as? OTRXMPPRoomOccupant)?.roomName ?? (object1 as? OTRXMPPRoomOccupant)?.realJID ?? (object1 as? OTRXMPPRoomOccupant)?.jid else {
+            guard let name1 = (object1 as? OTRXMPPRoomOccupant)?.roomName ?? (object1 as? OTRXMPPRoomOccupant)?.realJID ?? (object1 as? OTRXMPPRoomOccupant)?.jids?.first else {
                 return .orderedSame
             }
             
-            guard let name2 = (object2 as? OTRXMPPRoomOccupant)?.roomName ?? (object2 as? OTRXMPPRoomOccupant)?.realJID ?? (object2 as? OTRXMPPRoomOccupant)?.jid else {
+            guard let name2 = (object2 as? OTRXMPPRoomOccupant)?.roomName ?? (object2 as? OTRXMPPRoomOccupant)?.realJID ?? (object2 as? OTRXMPPRoomOccupant)?.jids?.first else {
                 return .orderedSame
             }
             

--- a/ChatSecure/Classes/Controllers/YapDatabase+ChatSecure.swift
+++ b/ChatSecure/Classes/Controllers/YapDatabase+ChatSecure.swift
@@ -58,11 +58,11 @@ public extension YapDatabase {
                 }
             }
             
-            guard let name1 = (object1 as? OTRXMPPRoomOccupant)?.roomName ?? (object1 as? OTRXMPPRoomOccupant)?.realJID ?? (object1 as? OTRXMPPRoomOccupant)?.jids?.first else {
+            guard let name1 = (object1 as? OTRXMPPRoomOccupant)?.roomName ?? (object1 as? OTRXMPPRoomOccupant)?.realJID ?? (object1 as? OTRXMPPRoomOccupant)?.jids.first?.full else {
                 return .orderedSame
             }
             
-            guard let name2 = (object2 as? OTRXMPPRoomOccupant)?.roomName ?? (object2 as? OTRXMPPRoomOccupant)?.realJID ?? (object2 as? OTRXMPPRoomOccupant)?.jids?.first else {
+            guard let name2 = (object2 as? OTRXMPPRoomOccupant)?.roomName ?? (object2 as? OTRXMPPRoomOccupant)?.realJID ?? (object2 as? OTRXMPPRoomOccupant)?.jids.first?.full else {
                 return .orderedSame
             }
             

--- a/ChatSecure/Classes/Controllers/YapDatabaseTransaction+ChatSecure.swift
+++ b/ChatSecure/Classes/Controllers/YapDatabaseTransaction+ChatSecure.swift
@@ -58,20 +58,20 @@ public extension YapDatabaseReadTransaction {
     }
     
     /** The jid here is the full jid not real jid or nickname */
-    @objc public func enumerateRoomOccupants(jid:String, block:@escaping (_ occupant:OTRXMPPRoomOccupant, _ stop:UnsafeMutablePointer<ObjCBool>) -> Void) {
-        guard let secondaryIndexTransaction = self.ext(SecondaryIndexName.signal) as? YapDatabaseSecondaryIndexTransaction else {
-            return
-        }
-        
-        let queryString = "Where \(RoomOccupantIndexColumnName.jid) = ?"
-        let query = YapDatabaseQuery(string: queryString, parameters: [jid])
-        
-        secondaryIndexTransaction.enumerateKeys(matching: query) { (collection, key, stop) -> Void in
-            if let occupant = self.object(forKey: key, inCollection: collection) as? OTRXMPPRoomOccupant {
-                block(occupant, stop)
-            }
-        }
-    }
+//    @objc public func enumerateRoomOccupants(jid:String, block:@escaping (_ occupant:OTRXMPPRoomOccupant, _ stop:UnsafeMutablePointer<ObjCBool>) -> Void) {
+//        guard let secondaryIndexTransaction = self.ext(SecondaryIndexName.signal) as? YapDatabaseSecondaryIndexTransaction else {
+//            return
+//        }
+//
+//        let queryString = "Where \(RoomOccupantIndexColumnName.jid) = ?"
+//        let query = YapDatabaseQuery(string: queryString, parameters: [jid])
+//
+//        secondaryIndexTransaction.enumerateKeys(matching: query) { (collection, key, stop) -> Void in
+//            if let occupant = self.object(forKey: key, inCollection: collection) as? OTRXMPPRoomOccupant {
+//                block(occupant, stop)
+//            }
+//        }
+//    }
     
     @objc public func numberOfUnreadMessages() -> UInt {
         guard let secondaryIndexTransaction = self.ext(SecondaryIndexName.messages) as? YapDatabaseSecondaryIndexTransaction else {

--- a/ChatSecure/Classes/Model/OTRBuddyCache.h
+++ b/ChatSecure/Classes/Model/OTRBuddyCache.h
@@ -11,15 +11,23 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class OTRXMPPRoom;
+
 /** Thread safe getters and setters for ephemeral in-memory storage of some buddy properties */
 @interface OTRBuddyCache : NSObject
 
 @property (class, nonatomic, readonly) OTRBuddyCache *shared;
 
 /** 
- Clears everything for a buddy
+ Clears everything for given buddies
  */
 - (void) purgeAllPropertiesForBuddies:(NSArray <OTRBuddy*>*)buddies;
+
+/**
+ Clears everything for given rooms
+ */
+- (void) purgeAllPropertiesForRooms:(NSArray <OTRXMPPRoom*>*)rooms;
+
 
 - (void) setChatState:(OTRChatState)chatState forBuddy:(OTRBuddy*)buddy;
 - (OTRChatState) chatStateForBuddy:(OTRBuddy*)buddy;
@@ -42,6 +50,18 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (nullable NSDate*) lastSeenDateForBuddy:(OTRBuddy*)buddy;
 - (void) setLastSeenDate:(nullable NSDate*)date forBuddy:(OTRBuddy*)buddy;
+
+/**
+ Room status
+ */
+- (void) setJoined:(BOOL)joined forRoom:(OTRXMPPRoom*)room;
+- (BOOL) joinedForRoom:(OTRXMPPRoom*)room;
+
+/**
+ Flag that indicates if we have fetched initial history for the room upon joining
+ */
+- (void) setHasFetchedHistory:(BOOL)hasFetchedHistory forRoom:(OTRXMPPRoom*)room;
+- (BOOL) hasFetchedHistoryForRoom:(OTRXMPPRoom*)room;
 
 @end
 NS_ASSUME_NONNULL_END

--- a/ChatSecure/Classes/Model/Yap Storage/Accounts/OTRXMPPAccount.h
+++ b/ChatSecure/Classes/Model/Yap Storage/Accounts/OTRXMPPAccount.h
@@ -9,7 +9,7 @@
 #import "OTRAccount.h"
 #import "OTRvCard.h"
 
-@class XMPPJID, XMPPStream, XMPPvCardTemp;
+@class XMPPJID, XMPPStream, XMPPvCardTemp, OTRXMPPRoom;
 
 NS_ASSUME_NONNULL_BEGIN
 @interface OTRXMPPAccount : OTRAccount <OTRvCard>
@@ -28,6 +28,9 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSString *)newResource;
 
 + (nullable instancetype)accountForStream:(XMPPStream *)stream transaction:(YapDatabaseReadTransaction *)transaction;
+
+/** Return all chat rooms for this account */
+- (NSArray <__kindof OTRXMPPRoom *>*)allRoomsWithTransaction:(YapDatabaseReadTransaction *)transaction;
 
 /** Returns the bare JID derived from the self.username property */
 @property (nonatomic, strong, readonly, nullable) XMPPJID *bareJID;

--- a/ChatSecure/Classes/Model/Yap Storage/Accounts/OTRXMPPAccount.m
+++ b/ChatSecure/Classes/Model/Yap Storage/Accounts/OTRXMPPAccount.m
@@ -9,6 +9,7 @@
 #import "OTRXMPPAccount.h"
 #import "OTRXMPPManager.h"
 #import "OTRConstants.h"
+#import <ChatSecureCore/ChatSecureCore-Swift.h>
 @import OTRAssets;
 
 @import XMPPFramework;
@@ -106,6 +107,20 @@ static NSUInteger const OTRDefaultPortNumber = 5222;
 
 - (nullable XMPPJID*) bareJID {
     return [XMPPJID jidWithString:self.username];
+}
+
+- (NSArray *)allRoomsWithTransaction:(YapDatabaseReadTransaction *)transaction
+{
+    NSMutableArray *allRooms = [NSMutableArray array];
+    NSString *extensionName = [YapDatabaseConstants extensionName:DatabaseExtensionNameRelationshipExtensionName];
+    NSString *edgeName = [YapDatabaseConstants edgeName:RelationshipEdgeNameRoom];
+    [[transaction ext:extensionName] enumerateEdgesWithName:edgeName destinationKey:self.uniqueId collection:[OTRAccount collection] usingBlock:^(YapDatabaseRelationshipEdge *edge, BOOL *stop) {
+        OTRXMPPRoom *room = [OTRXMPPRoom fetchObjectWithUniqueID:edge.sourceKey transaction:transaction];
+        if (room) {
+            [allRooms addObject:room];
+        }
+    }];
+    return allRooms;
 }
 
 @end

--- a/ChatSecure/Classes/Model/Yap Storage/OTRXMPPRoom.swift
+++ b/ChatSecure/Classes/Model/Yap Storage/OTRXMPPRoom.swift
@@ -36,6 +36,10 @@ import YapDatabase.YapDatabaseRelationship
     @objc open var lastRoomMessageId:String?
     @objc open var subject:String?
     @objc open var roomPassword:String?
+
+    // A transient property, keeps track of if we have done an initial MAM history fetch after room has been joined.
+    @objc open var hasFetchedHistory = false
+    
     override open var uniqueId:String {
         get {
             if let account = self.accountUniqueId {
@@ -56,6 +60,13 @@ import YapDatabase.YapDatabaseRelationship
             return nil
         }
         return OTRXMPPRoom.fetchObject(withUniqueID: roomYapKey, transaction: transaction)
+    }
+    
+    @objc override open class func storageBehaviorForProperty(withKey key:String) -> MTLPropertyStorage {
+        if key == #keyPath(hasFetchedHistory) {
+            return MTLPropertyStorageTransitory
+        }
+        return super.storageBehaviorForProperty(withKey: key)
     }
 }
 

--- a/ChatSecure/Classes/Model/Yap Storage/OTRXMPPRoom.swift
+++ b/ChatSecure/Classes/Model/Yap Storage/OTRXMPPRoom.swift
@@ -30,15 +30,30 @@ import YapDatabase.YapDatabaseRelationship
             return nil
         }
     }
-    
-    @objc open var joined = false
+
     @objc open var messageText:String?
     @objc open var lastRoomMessageId:String?
     @objc open var subject:String?
     @objc open var roomPassword:String?
 
-    // A transient property, keeps track of if we have done an initial MAM history fetch after room has been joined.
-    @objc open var hasFetchedHistory = false
+    // Transient properties stored in OTRBuddyCache
+    @objc open var joined:Bool {
+        get {
+            return OTRBuddyCache.shared.joined(for: self)
+        }
+        set (value) {
+            OTRBuddyCache.shared.setJoined(value, for: self)
+        }
+    }
+    
+    @objc open var hasFetchedHistory:Bool {
+        get {
+            return OTRBuddyCache.shared.hasFetchedHistory(for: self)
+        }
+        set (value) {
+            OTRBuddyCache.shared.setHasFetchedHistory(value, for: self)
+        }
+    }
     
     override open var uniqueId:String {
         get {
@@ -63,8 +78,8 @@ import YapDatabase.YapDatabaseRelationship
     }
     
     @objc override open class func storageBehaviorForProperty(withKey key:String) -> MTLPropertyStorage {
-        if key == #keyPath(hasFetchedHistory) {
-            return MTLPropertyStorageTransitory
+        if key == #keyPath(hasFetchedHistory) || key == #keyPath(joined) {
+            return MTLPropertyStorageNone
         }
         return super.storageBehaviorForProperty(withKey: key)
     }

--- a/ChatSecure/Classes/Model/Yap Storage/OTRXMPPRoomOccupant.swift
+++ b/ChatSecure/Classes/Model/Yap Storage/OTRXMPPRoomOccupant.swift
@@ -138,7 +138,7 @@ open class OTRXMPPRoomOccupant: OTRYapDatabaseObject, YapDatabaseRelationshipNod
     }
     
     open override func decodeValue(forKey key: String!, with coder: NSCoder!, modelVersion: UInt) -> Any! {
-        if modelVersion == 0, key == "jids" {
+        if modelVersion == 0, key == "_jids" {
             if let jid = coder.decodeObject(forKey: "jid") as? String {
                 return [jid]
             }
@@ -150,6 +150,12 @@ open class OTRXMPPRoomOccupant: OTRYapDatabaseObject, YapDatabaseRelationshipNod
         return 1
     }
     
+    @objc override open class func storageBehaviorForProperty(withKey key:String) -> MTLPropertyStorage {
+        if key == #keyPath(available) || key == #keyPath(jids) {
+            return MTLPropertyStorageNone
+        }
+        return super.storageBehaviorForProperty(withKey: key)
+    }
 }
 
 public extension OTRXMPPRoomOccupant {

--- a/ChatSecure/Classes/Model/Yap Storage/OTRXMPPRoomOccupant.swift
+++ b/ChatSecure/Classes/Model/Yap Storage/OTRXMPPRoomOccupant.swift
@@ -93,10 +93,12 @@ open class OTRXMPPRoomOccupant: OTRYapDatabaseObject, YapDatabaseRelationshipNod
     
     @objc open static let roomEdgeName = "OTRRoomOccupantEdgeName"
     
-    @objc open var available = false
+    @objc open var available:Bool {
+        return (jids?.count ?? 0) > 0
+    }
     
-    /** This is the JID of the participant as it's known in the room i.e. baseball_chat@conference.dukgo.com/user123 */
-    @objc open var jid:String?
+    /** This is all JIDs of the participant as it's known in the room i.e. baseball_chat@conference.dukgo.com/user123 */
+    @objc open var jids:[String]?
     
     /** This is the name your known as in the room. Seems to be username without domain */
     @objc open var roomName:String?
@@ -114,7 +116,7 @@ open class OTRXMPPRoomOccupant: OTRYapDatabaseObject, YapDatabaseRelationshipNod
     @objc open var roomUniqueId:String?
     
     @objc open func avatarImage() -> UIImage {
-        return OTRImages.avatarImage(withUniqueIdentifier: self.uniqueId, avatarData: nil, displayName: roomName ?? realJID ?? jid, username: self.realJID)
+        return OTRImages.avatarImage(withUniqueIdentifier: self.uniqueId, avatarData: nil, displayName: roomName ?? realJID ?? jids?.first, username: self.realJID)
     }
     
     //MARK: YapDatabaseRelationshipNode Methods
@@ -133,6 +135,19 @@ open class OTRXMPPRoomOccupant: OTRYapDatabaseObject, YapDatabaseRelationshipNod
             return OTRXMPPBuddy.fetchObject(withUniqueID: buddyUniqueId, transaction: transaction)
         }
         return nil
+    }
+    
+    open override func decodeValue(forKey key: String!, with coder: NSCoder!, modelVersion: UInt) -> Any! {
+        if modelVersion == 0, key == "jids" {
+            if let jid = coder.decodeObject(forKey: "jid") as? String {
+                return [jid]
+            }
+        }
+        return super.decodeValue(forKey: key, with: coder, modelVersion: modelVersion)
+    }
+    
+    open class override func modelVersion() -> UInt {
+        return 1
     }
     
 }
@@ -161,8 +176,9 @@ public extension OTRXMPPRoomOccupant {
         
         var parameters: [String] = [roomUniqueId]
         var queryString = "Where \(RoomOccupantIndexColumnName.roomUniqueId) == ? AND ("
-        parameters.append(jid.full)
-        queryString.append("\(RoomOccupantIndexColumnName.jid) == ?")
+        // We build the secondary index with appended \0 to avoid matching wrong jids, so add a matching \0s here.
+        parameters.append("%\t\(jid.full)\t%")
+        queryString.append("\(RoomOccupantIndexColumnName.jids) LIKE ?")
         if let realJID = realJID {
             parameters.append(realJID.bare)
             queryString.append(" OR \(RoomOccupantIndexColumnName.realJID) == ?")
@@ -188,12 +204,15 @@ public extension OTRXMPPRoomOccupant {
         if occupant == nil,
             createIfNeeded {
             occupant = OTRXMPPRoomOccupant()!
-            occupant?.jid = jid.full
-            occupant?.realJID = realJID?.bare
             occupant?.roomUniqueId = roomUniqueId
             didCreate = true
         }
         
+        // Set realJID?
+        if let occupant = occupant, let realJID = realJID, occupant.realJID == nil {
+            occupant.realJID = realJID.bare
+        }
+
         // While we're at it, match room occupant with a buddy on our roster if possible
         // This should probably be moved elsewhere
         if let existingOccupant = occupant,
@@ -206,7 +225,28 @@ public extension OTRXMPPRoomOccupant {
             }
             occupant?.buddyUniqueId = buddy.uniqueId
         }
-        
         return occupant
+    }
+}
+
+// Extension for adding/removing jids from the jids array
+public extension OTRXMPPRoomOccupant {
+    @objc public func addJid(_ jid:String) {
+        if jid != realJID {
+            if jids == nil {
+                jids = [jid]
+            } else if let jids = jids, !jids.contains(jid) {
+                self.jids?.append(jid)
+            }
+        }
+    }
+    
+    @objc public func removeJid(_ jid:String) {
+        if let index = jids?.index(of: jid) {
+            jids?.remove(at: index)
+            if jids?.count == 0 {
+                jids = nil
+            }
+        }
     }
 }

--- a/ChatSecure/Classes/Model/Yap Storage/SecondaryIndexes.swift
+++ b/ChatSecure/Classes/Model/Yap Storage/SecondaryIndexes.swift
@@ -127,9 +127,11 @@ public extension YapDatabaseSecondaryIndex {
             guard let occupant = object as? OTRXMPPRoomOccupant else {
                 return
             }
-            if let jids = occupant.jids, jids.count > 0 {
+            if occupant.jids.count > 0 {
                 // Concatenate all jids with a null character \t so we can use a LIKE %\tjid\t construct to look them up without risking partial matches with other jids!
-                dict[RoomOccupantIndexColumnName.jids] = "\t".appending(jids.joined(separator: "\t")).appending("\t")
+                dict[RoomOccupantIndexColumnName.jids] = "\t".appending(occupant.jids.flatMap { (jid) -> String in
+                        jid.full
+                    }.joined(separator: "\t")).appending("\t")
             }
             if let realJID = occupant.realJID, realJID.count > 0 {
                 dict[RoomOccupantIndexColumnName.realJID] = realJID

--- a/ChatSecure/Classes/Model/Yap Storage/SecondaryIndexes.swift
+++ b/ChatSecure/Classes/Model/Yap Storage/SecondaryIndexes.swift
@@ -113,7 +113,7 @@ public extension YapDatabaseSecondaryIndex {
     
     @objc public static var roomOccupantIndex: YapDatabaseSecondaryIndex {
         let columns: [String:YapDatabaseSecondaryIndexType] = [
-            RoomOccupantIndexColumnName.jid: .text,
+            RoomOccupantIndexColumnName.jids: .text,
             RoomOccupantIndexColumnName.realJID: .text,
             RoomOccupantIndexColumnName.roomUniqueId: .text,
             RoomOccupantIndexColumnName.buddyUniqueId: .text,
@@ -127,8 +127,9 @@ public extension YapDatabaseSecondaryIndex {
             guard let occupant = object as? OTRXMPPRoomOccupant else {
                 return
             }
-            if let jid = occupant.jid, jid.count > 0 {
-                dict[RoomOccupantIndexColumnName.jid] = jid
+            if let jids = occupant.jids, jids.count > 0 {
+                // Concatenate all jids with a null character \t so we can use a LIKE %\tjid\t construct to look them up without risking partial matches with other jids!
+                dict[RoomOccupantIndexColumnName.jids] = "\t".appending(jids.joined(separator: "\t")).appending("\t")
             }
             if let realJID = occupant.realJID, realJID.count > 0 {
                 dict[RoomOccupantIndexColumnName.realJID] = realJID
@@ -141,7 +142,7 @@ public extension YapDatabaseSecondaryIndex {
             }
         }
         let options = YapDatabaseSecondaryIndexOptions(whitelist: [OTRXMPPRoomOccupant.collection])
-        let secondaryIndex = YapDatabaseSecondaryIndex(setup: setup, handler: handler, versionTag: "4", options: options)
+        let secondaryIndex = YapDatabaseSecondaryIndex(setup: setup, handler: handler, versionTag: "5", options: options)
         return secondaryIndex
     }
 }
@@ -244,8 +245,8 @@ public extension OTRXMPPBuddy {
 }
 
 @objc public class RoomOccupantIndexColumnName: NSObject {
-    /// jid
-    @objc public static let jid = "OTRYapDatabaseRoomOccupantJidSecondaryIndexColumnName"
+    /// jids
+    @objc public static let jids = "OTRYapDatabaseRoomOccupantJidSecondaryIndexColumnName"
     @objc public static let realJID = "RoomOccupantIndexColumnName_realJID"
     @objc public static let roomUniqueId = "RoomOccupantIndexColumnName_roomUniqueId"
     @objc public static let buddyUniqueId = "RoomOccupantIndexColumnName_buddyUniqueId"

--- a/ChatSecure/Classes/Utilities/OTRChatDemo.h
+++ b/ChatSecure/Classes/Utilities/OTRChatDemo.h
@@ -12,5 +12,6 @@
 
 + (void)loadDemoChatInDatabase;
 + (void)loadPerformanceTestChatsInDatabase;
-
++ (void)addDummyMessagesForExistingAccount:(NSString*)accountJid toFromBuddy:(NSString*)buddyJid count:(int)count;
+    
 @end

--- a/ChatSecure/Classes/View Controllers/OTRComposeGroupViewController.swift
+++ b/ChatSecure/Classes/View Controllers/OTRComposeGroupViewController.swift
@@ -219,14 +219,13 @@ open class OTRComposeGroupViewController: UIViewController, UICollectionViewDele
     open func setExistingRoomOccupants(viewHandler:OTRYapViewHandler?, room:OTRXMPPRoom?) {
         self.waitingForExcludedItems = true
         DispatchQueue.global().async {
-            if let room = room, let viewHandler = viewHandler, let mappings = viewHandler.mappings {
+            if let viewHandler = viewHandler, let mappings = viewHandler.mappings {
                 for section in 0..<mappings.numberOfSections() {
                     for row in 0..<mappings.numberOfItems(inSection: section) {
                         var buddy:OTRXMPPBuddy? = nil
-                        if let roomOccupant = viewHandler.object(IndexPath(row: Int(row), section: Int(section))) as? OTRXMPPRoomOccupant,
-                            let jidString = roomOccupant.realJID ?? roomOccupant.jid, let jid = XMPPJID(string: jidString), let account = room.accountUniqueId {
+                        if let roomOccupant = viewHandler.object(IndexPath(row: Int(row), section: Int(section))) as? OTRXMPPRoomOccupant {
                             OTRDatabaseManager.shared.readOnlyDatabaseConnection?.read({ (transaction) in
-                                buddy = OTRXMPPBuddy.fetchBuddy(jid: jid, accountUniqueId: account, transaction: transaction)
+                                buddy = roomOccupant.buddy(with: transaction)
                             })
                             if let buddy = buddy {
                                 self.existingItems.insert(buddy.uniqueId)

--- a/ChatSecure/Classes/View Controllers/OTRMessagesCollectionViewFlowLayout.swift
+++ b/ChatSecure/Classes/View Controllers/OTRMessagesCollectionViewFlowLayout.swift
@@ -46,19 +46,31 @@ import JSQMessagesViewController
         return CGSize(width: 1, height: 0)
     }
     
-    override open func prepare() {
-        super.prepare()
-        self.supplementaryViews.removeAll()
-        if let delegate = self.supplementaryViewDelegate {
-            for section in 0..<self.collectionView.numberOfSections {
-                for item in 0..<self.collectionView.numberOfItems(inSection: section) {
-                    if let views = delegate.supplementaryViewsForCellAtIndexPath(IndexPath(item: item, section: section)) {
-                        let index = cacheIndexFor(item: item, section: section)
+    override open func invalidateLayout(with context: UICollectionViewLayoutInvalidationContext) {
+        if context.invalidateEverything || context.invalidateDataSourceCounts {
+            self.supplementaryViews.removeAll()
+            if let delegate = self.supplementaryViewDelegate {
+                for section in 0..<self.collectionView.numberOfSections {
+                    for item in 0..<self.collectionView.numberOfItems(inSection: section) {
+                        if let views = delegate.supplementaryViewsForCellAtIndexPath(IndexPath(item: item, section: section)) {
+                            let index = cacheIndexFor(item: item, section: section)
+                            supplementaryViews[index] = views
+                        }
+                    }
+                }
+            }
+        } else {
+            for indexPath in context.invalidatedItemIndexPaths ?? [] {
+                let index = cacheIndexFor(item: indexPath.item, section: indexPath.section)
+                self.supplementaryViews[index] = nil
+                if let delegate = self.supplementaryViewDelegate {
+                    if let views = delegate.supplementaryViewsForCellAtIndexPath(IndexPath(item: indexPath.item, section: indexPath.section)) {
                         supplementaryViews[index] = views
                     }
                 }
             }
         }
+        super.invalidateLayout(with: context)
     }
     
     open override var collectionViewContentSize: CGSize {

--- a/ChatSecure/Classes/View Controllers/OTRMessagesViewController.m
+++ b/ChatSecure/Classes/View Controllers/OTRMessagesViewController.m
@@ -1818,7 +1818,7 @@ typedef NS_ENUM(int, OTRDropDownType) {
                             displayName = occupant.roomName;
                         } else {
                             if (occupant.jids && occupant.jids.count > 0) {
-                                displayName = [[XMPPJID jidWithString:occupant.jids[0]] resource];
+                                displayName = [[occupant.jids anyObject] resource];
                             }
                         }
                     }

--- a/ChatSecure/Classes/View Controllers/OTRMessagesViewController.m
+++ b/ChatSecure/Classes/View Controllers/OTRMessagesViewController.m
@@ -886,11 +886,7 @@ typedef NS_ENUM(int, OTRDropDownType) {
 }
 
 - (BOOL) isGroupChat {
-    __block OTRXMPPRoom *room = nil;
-    [self.readOnlyDatabaseConnection readWithBlock:^(YapDatabaseReadTransaction * _Nonnull transaction) {
-        room = [self roomWithTransaction:transaction];
-    }];
-    return (room != nil);
+    return [self.threadCollection isEqualToString:OTRXMPPRoom.collection];
 }
 
 #pragma - mark Profile Button Methods
@@ -1203,11 +1199,13 @@ typedef NS_ENUM(int, OTRDropDownType) {
     
     [self.collectionView reloadData];
     
+    __block NSUInteger shownCount;
+    __block NSUInteger totalCount;
     [self.readOnlyDatabaseConnection readWithBlock:^(YapDatabaseReadTransaction *_Nonnull transaction) {
-        NSUInteger shownCount = [self.viewHandler.mappings numberOfItemsInGroup:self.threadKey];
-        NSUInteger totalCount = [[transaction ext:OTRFilteredChatDatabaseViewExtensionName] numberOfItemsInGroup:self.threadKey];
-        [self setShowLoadEarlierMessagesHeader:shownCount < totalCount];
+        shownCount = [self.viewHandler.mappings numberOfItemsInGroup:self.threadKey];
+        totalCount = [[transaction ext:OTRFilteredChatDatabaseViewExtensionName] numberOfItemsInGroup:self.threadKey];
     }];
+    [self setShowLoadEarlierMessagesHeader:shownCount < totalCount];
     
     if (!reset) {
         [self.collectionView.collectionViewLayout invalidateLayout];

--- a/ChatSecure/Classes/View Controllers/OTRMessagesViewController.m
+++ b/ChatSecure/Classes/View Controllers/OTRMessagesViewController.m
@@ -1688,7 +1688,7 @@ typedef NS_ENUM(int, OTRDropDownType) {
                 roomOccupantBuddy = [OTRXMPPBuddy fetchObjectWithUniqueID:roomMessage.buddyUniqueId transaction:transaction];
             }
             if (!roomOccupantBuddy) {
-                roomOccupant = [OTRXMPPRoomOccupant occupantWithJid:[XMPPJID jidWithString:roomMessage.senderJID] realJID:[XMPPJID jidWithString:roomMessage.senderJID] roomJID:[XMPPJID jidWithString:roomMessage.roomJID] accountId:[self accountWithTransaction:transaction].uniqueId createIfNeeded:NO transaction:transaction];
+                roomOccupant = [OTRXMPPRoomOccupant occupantWithJid:[XMPPJID jidWithString:roomMessage.senderJID] realJID:nil roomJID:[XMPPJID jidWithString:roomMessage.roomJID] accountId:[self accountWithTransaction:transaction].uniqueId createIfNeeded:NO transaction:transaction];
                 if (roomOccupant != nil) {
                     roomOccupantBuddy = [roomOccupant buddyWith:transaction];
                 }
@@ -1816,8 +1816,12 @@ typedef NS_ENUM(int, OTRDropDownType) {
                         OTRXMPPBuddy *buddy = [occupant buddyWith:transaction];
                         if (buddy) {
                             displayName = [buddy displayName];
+                        } else if (occupant.roomName) {
+                            displayName = occupant.roomName;
                         } else {
-                            displayName = [[XMPPJID jidWithString:occupant.jid] resource];
+                            if (occupant.jids && occupant.jids.count > 0) {
+                                displayName = [[XMPPJID jidWithString:occupant.jids[0]] resource];
+                            }
                         }
                     }
                 }

--- a/ChatSecure/Classes/View Controllers/OTRRoomOccupantsViewController.swift
+++ b/ChatSecure/Classes/View Controllers/OTRRoomOccupantsViewController.swift
@@ -399,7 +399,7 @@ extension OTRRoomOccupantsViewController: UITableViewDataSource {
                 // Do not save here or it will auto-trust random people
                 let uniqueId = roomJid + account
                 let buddy = OTRXMPPBuddy(uniqueId: uniqueId)
-                buddy.username = roomOccupant.jids?.first ?? roomOccupant.realJID ?? ""
+                buddy.username = roomOccupant.realJID ?? roomOccupant.jids?.first ?? ""
                 buddy.displayName = roomOccupant.roomName ?? buddy.username
                 var status: OTRThreadStatus = .available
                 if !roomOccupant.available {

--- a/ChatSecure/Classes/View Controllers/OTRRoomOccupantsViewController.swift
+++ b/ChatSecure/Classes/View Controllers/OTRRoomOccupantsViewController.swift
@@ -363,6 +363,7 @@ extension OTRRoomOccupantsViewController: OTRYapViewHandlerDelegateProtocol {
         //TODO: pretty animations
         self.tableView?.reloadData()
         self.updateUIBasedOnOwnRole()
+        self.view.setNeedsLayout()
     }
 }
 

--- a/ChatSecure/Classes/View Controllers/OTRRoomOccupantsViewController.swift
+++ b/ChatSecure/Classes/View Controllers/OTRRoomOccupantsViewController.swift
@@ -399,7 +399,7 @@ extension OTRRoomOccupantsViewController: UITableViewDataSource {
                 // Do not save here or it will auto-trust random people
                 let uniqueId = roomJid + account
                 let buddy = OTRXMPPBuddy(uniqueId: uniqueId)
-                buddy.username = roomOccupant.realJID ?? roomOccupant.jids?.first ?? ""
+                buddy.username = roomOccupant.realJID ?? roomOccupant.jids.first?.full ?? ""
                 buddy.displayName = roomOccupant.roomName ?? buddy.username
                 var status: OTRThreadStatus = .available
                 if !roomOccupant.available {


### PR DESCRIPTION
I think we have a few things to discuss here, but wanted to get the code up there at least.

- [ ] The secondary index code is a real hack now, looking up a jid in an array. Currently done by wrapping each jid in \t and doing an SQL LIKE query. What's a good fix?
- [ ] enumerateRoomOccupants, which uses the secondary index, was unused so I commented it out. Remove altogether?
- [ ] Is there a good way to know if MAM support is available when joining a room, i.e. do we know if the call to "fetchHistory" will succeed? In that case we should set the "traditional" history element to maxChars = 0 when joining so that we don't have to deal with duplicate incoming messages. Also, we prefer to get them from MAM because we get the desired "item" element so we can map the messages to actual sender buddies (in the "traditional" history we can only succeed with this if the sender is available in the room, i.e. an "occupant" in the XMPP sense. If they are offline we can't).