### PR TITLE
Knock button would immediately be overwritten?

### DIFF
--- a/ChatSecure/Classes/View Controllers/OTRMessagesHoldTalkViewController.m
+++ b/ChatSecure/Classes/View Controllers/OTRMessagesHoldTalkViewController.m
@@ -219,8 +219,10 @@ static Float64 kOTRMessagesMinimumAudioTime = .5;
 
 - (void)didUpdateState
 {
+    BOOL showKnockButton = NO;
     if (self.state.canKnock && !self.state.isThreadOnline && !self.state.hasText) {
         //Show Knock Button
+        showKnockButton = YES;
         self.inputToolbar.contentView.rightBarButtonItem = self.knockButton;
         self.inputToolbar.sendButtonLocation = JSQMessagesInputSendButtonLocationNone;
         self.inputToolbar.contentView.rightBarButtonItem.enabled = YES;
@@ -240,13 +242,15 @@ static Float64 kOTRMessagesMinimumAudioTime = .5;
         
         if (!self.state.hasText) {
             //No text then show microphone
-            if ([self.hold2TalkButton superview]) {
-                self.inputToolbar.contentView.rightBarButtonItem = self.keyboardButton;
-            } else {
-                self.inputToolbar.contentView.rightBarButtonItem = self.microphoneButton;
+            if (!showKnockButton) {
+                if ([self.hold2TalkButton superview]) {
+                    self.inputToolbar.contentView.rightBarButtonItem = self.keyboardButton;
+                } else {
+                    self.inputToolbar.contentView.rightBarButtonItem = self.microphoneButton;
+                }
+                self.inputToolbar.sendButtonLocation = JSQMessagesInputSendButtonLocationNone;
+                self.inputToolbar.contentView.rightBarButtonItem.enabled = YES;
             }
-            self.inputToolbar.sendButtonLocation = JSQMessagesInputSendButtonLocationNone;
-            self.inputToolbar.contentView.rightBarButtonItem.enabled = YES;
         } else {
             //Default Send button
             [self setupDefaultSendButton];


### PR DESCRIPTION
Maybe just my ignorance about how the knock button works, but it seems to me that the knock button would be replaced by mic/keyboard on all servers that support http uploads? Maybe this is intended behavior? I haven't been able to test the knock functionality, unsure exactly what would trigger it.