### PR TITLE
Wait for authenticated before start sending IQ stanzas.

### DIFF
--- a/ChatSecure/Classes/Controllers/ServerCheck.swift
+++ b/ChatSecure/Classes/Controllers/ServerCheck.swift
@@ -75,7 +75,7 @@ public class ServerCheck: XMPPModule {
     // MARK: Public API
     
     @objc public func getCombinedPushStatus() -> ServerCheckPushStatus {
-        if let xmpp = xmppStream, xmpp.state != .STATE_XMPP_CONNECTED {
+        if let xmpp = xmppStream, xmpp.state != .STATE_XMPP_CONNECTED || !xmpp.isAuthenticated {
             return .unknown
         }
         return result.getCombinedPushStatus()

--- a/ChatSecure/Classes/Controllers/XMPP/OTRServerCapabilities.m
+++ b/ChatSecure/Classes/Controllers/XMPP/OTRServerCapabilities.m
@@ -188,6 +188,10 @@ static NSString *const OTRServerCapabilitiesErrorDomain = @"OTRServerCapabilitie
             XMPPLogError(@"OTRServerCapabilities: fetchAllCapabilities error - not connected. %@", self);
             return;
         }
+        if (![xmppStream isAuthenticated]) {
+            XMPPLogError(@"OTRServerCapabilities: fetchAllCapabilities error - not authenticated. %@", self);
+            return;
+        }
         [self discoverServices];
         [self fetchCapabilitiesForJIDs:self.allJIDs];
     }];


### PR DESCRIPTION
In about 1 in 10 starts of the app I noticed didNotAuthenticate was
called, because IQ stanza was sent (and the response taken for an auth
response error) before auth was done.