### PR TITLE
WIP: More occupant fixes

### DIFF
--- a/ChatSecure/Classes/Controllers/XMPP/OTRXMPPRoomManager.m
+++ b/ChatSecure/Classes/Controllers/XMPP/OTRXMPPRoomManager.m
@@ -10,6 +10,7 @@
 @import XMPPFramework;
 #import <ChatSecureCore/ChatSecureCore-Swift.h>
 #import "OTRBuddy.h"
+#import "OTRBuddyCache.h"
 @import YapDatabase;
 #import "OTRLog.h"
 
@@ -364,33 +365,68 @@
 
 #pragma - mark XMPPRoomDelegate Methods
 
-// After we have gotten the initial room subject we are ready for live messages. Go ahead and fetch MAM history now.
-- (void)xmppRoomDidChangeSubject:(XMPPRoom *)sender {
-    NSString *databaseRoomKey = [OTRXMPPRoom createUniqueId:self.xmppStream.tag jid:[sender.roomJID bare]];
+- (OTRXMPPRoom*)roomWithXMPPRoom:(XMPPRoom*)xmppRoom {
+    NSString *databaseRoomKey = [OTRXMPPRoom createUniqueId:self.xmppStream.tag jid:[xmppRoom.roomJID bare]];
+    __block OTRXMPPRoom *room = nil;
     [self.databaseConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction * _Nonnull transaction) {
-        OTRXMPPRoom *room = [OTRXMPPRoom fetchObjectWithUniqueID:databaseRoomKey transaction:transaction];
-        if (room) {
-            if (!room.hasFetchedHistory) {
-                room.hasFetchedHistory = YES;
-                [self fetchHistoryFor:sender];
-            }
-        }
+        room = [OTRXMPPRoom fetchObjectWithUniqueID:databaseRoomKey transaction:transaction];
     }];
+    return room;
+}
+
+- (OTRXMPPRoomRuntimeProperties *)roomRuntimeProperties:(XMPPRoom*)xmppRoom {
+    OTRXMPPRoom *room = [self roomWithXMPPRoom:xmppRoom];
+    if (room) {
+        return [OTRBuddyCache.shared runtimePropertiesForRoom:room];
+    }
+    return nil;
+}
+
+- (void) fetchHistoryIfListsDownloaded:(XMPPRoom *)xmppRoom {
+    OTRXMPPRoomRuntimeProperties *properties = [self roomRuntimeProperties:xmppRoom];
+    if (properties && !properties.hasFetchedHistory &&
+        properties.hasFetchedMembers &&
+        properties.hasFetchedAdmins &&
+        properties.hasFetchedOwners) {
+        properties.hasFetchedHistory = YES;
+        [self fetchHistoryFor:xmppRoom];
+    }
 }
 
 - (void) xmppRoom:(XMPPRoom *)room didFetchMembersList:(NSArray<NSXMLElement*> *)items {
     DDLogInfo(@"Fetched members list: %@", items);
     [self xmppRoom:room addOccupantItems:items];
+    [[self roomRuntimeProperties:room] setHasFetchedMembers:YES];
+    [self fetchHistoryIfListsDownloaded:room];
+}
+
+- (void)xmppRoom:(XMPPRoom *)room didNotFetchMembersList:(XMPPIQ *)iqError {
+    [[self roomRuntimeProperties:room] setHasFetchedMembers:YES];
+    [self fetchHistoryIfListsDownloaded:room];
 }
 
 - (void) xmppRoom:(XMPPRoom *)room didFetchAdminsList:(NSArray<NSXMLElement*> *)items {
     DDLogInfo(@"Fetched admins list: %@", items);
     [self xmppRoom:room addOccupantItems:items];
+    [[self roomRuntimeProperties:room] setHasFetchedAdmins:YES];
+    [self fetchHistoryIfListsDownloaded:room];
+}
+     
+- (void)xmppRoom:(XMPPRoom *)room didNotFetchAdminsList:(XMPPIQ *)iqError {
+    [[self roomRuntimeProperties:room] setHasFetchedAdmins:YES];
+    [self fetchHistoryIfListsDownloaded:room];
 }
 
 - (void) xmppRoom:(XMPPRoom *)room didFetchOwnersList:(NSArray<NSXMLElement*> *)items {
     DDLogInfo(@"Fetched owners list: %@", items);
     [self xmppRoom:room addOccupantItems:items];
+    [[self roomRuntimeProperties:room] setHasFetchedOwners:YES];
+    [self fetchHistoryIfListsDownloaded:room];
+}
+
+- (void)xmppRoom:(XMPPRoom *)room didNotFetchOwnersList:(XMPPIQ *)iqError {
+    [[self roomRuntimeProperties:room] setHasFetchedOwners:YES];
+    [self fetchHistoryIfListsDownloaded:room];
 }
 
 - (void)xmppRoom:(XMPPRoom *)room didFetchModeratorsList:(NSArray *)items {

--- a/ChatSecure/Classes/Controllers/XMPP/Storage/RoomStorage.swift
+++ b/ChatSecure/Classes/Controllers/XMPP/Storage/RoomStorage.swift
@@ -162,16 +162,25 @@ extension RoomStorage: XMPPRoomStorage {
             if let buddyJidString = item.attributeStringValue(forName: "jid") {
                 buddyJID = XMPPJID(string: buddyJidString)?.bareJID
             }
-            guard let occupant = OTRXMPPRoomOccupant.occupant(jid: presenceJID, realJID: buddyJID, roomJID: room.roomJID, accountId: accountId, createIfNeeded: true, transaction: transaction)?.copyAsSelf() else {
+            
+            // Is this nickname stored as belonging to someone else? In that case we need to remove that old mapping.
+            var occupantByJID = OTRXMPPRoomOccupant.occupant(jid: presenceJID, realJID: nil, roomJID: room.roomJID, accountId: accountId, createIfNeeded: false, transaction: transaction)?.copyAsSelf()
+            if let occupant = occupantByJID, let buddyRealJid = buddyJID, let oldRealJid = occupant.realJID, oldRealJid != buddyRealJid.full {
+                DDLogVerbose("Change nickname mapping from \(oldRealJid) to \(buddyRealJid)")
+                occupant.removeJid(presenceJID)
+                occupant.save(with: transaction)
+                occupantByJID = nil
+            }
+            
+            guard let occupant = occupantByJID ?? OTRXMPPRoomOccupant.occupant(jid: presenceJID, realJID: buddyJID, roomJID: room.roomJID, accountId: accountId, createIfNeeded: true, transaction: transaction)?.copyAsSelf() else {
                 DDLogWarn("Could not create room occupant")
                 return
             }
             let role = item.attributeStringValue(forName: "role") ?? ""
             let affiliation = item.attributeStringValue(forName: "affiliation") ?? ""
-            if presence.presenceType == .unavailable {
-                occupant.removeJid(presenceJID)
-            } else {
-                occupant.addJid(presenceJID)
+            occupant.addJid(presenceJID)
+            if let room = OTRXMPPRoom.fetch(xmppRoom: room, transaction: transaction) {
+                OTRBuddyCache.shared.setJid(presenceJID.full, online: presence.presenceType != .unavailable, in:room)
             }
             occupant.roomName = presenceJID.resource
             occupant.role = RoomOccupantRole(stringValue: role)

--- a/ChatSecure/Classes/Model/OTRBuddyCache.h
+++ b/ChatSecure/Classes/Model/OTRBuddyCache.h
@@ -12,6 +12,8 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class OTRXMPPRoom;
+typedef SWIFT_ENUM(NSInteger, RoomOccupantRole);
+@class OTRXMPPRoomOccupant;
 
 @interface OTRXMPPRoomRuntimeProperties : NSObject
 @property (nonatomic) BOOL joined;
@@ -19,6 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) BOOL hasFetchedOwners;
 @property (nonatomic) BOOL hasFetchedAdmins;
 @property (nonatomic) BOOL hasFetchedMembers;
+@property (nonatomic, strong) NSMutableArray *onlineJids;
 @end
 
 /** Thread safe getters and setters for ephemeral in-memory storage of some buddy properties */
@@ -63,6 +66,9 @@ NS_ASSUME_NONNULL_BEGIN
  Cached room properties
  */
 - (nullable OTRXMPPRoomRuntimeProperties *) runtimePropertiesForRoom:(OTRXMPPRoom*)room;
+
+- (void) setJid:(nonnull NSString*)jid online:(BOOL)online inRoom:(nonnull OTRXMPPRoom*)room;
+- (BOOL) jidOnline:(NSString*)jid inRoom:(nonnull OTRXMPPRoom*)room;
 
 @end
 NS_ASSUME_NONNULL_END

--- a/ChatSecure/Classes/Model/OTRBuddyCache.h
+++ b/ChatSecure/Classes/Model/OTRBuddyCache.h
@@ -13,6 +13,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class OTRXMPPRoom;
 
+@interface OTRXMPPRoomRuntimeProperties : NSObject
+@property (nonatomic) BOOL joined;
+@property (nonatomic) BOOL hasFetchedHistory;
+@property (nonatomic) BOOL hasFetchedOwners;
+@property (nonatomic) BOOL hasFetchedAdmins;
+@property (nonatomic) BOOL hasFetchedMembers;
+@end
+
 /** Thread safe getters and setters for ephemeral in-memory storage of some buddy properties */
 @interface OTRBuddyCache : NSObject
 
@@ -52,16 +60,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void) setLastSeenDate:(nullable NSDate*)date forBuddy:(OTRBuddy*)buddy;
 
 /**
- Room status
+ Cached room properties
  */
-- (void) setJoined:(BOOL)joined forRoom:(OTRXMPPRoom*)room;
-- (BOOL) joinedForRoom:(OTRXMPPRoom*)room;
-
-/**
- Flag that indicates if we have fetched initial history for the room upon joining
- */
-- (void) setHasFetchedHistory:(BOOL)hasFetchedHistory forRoom:(OTRXMPPRoom*)room;
-- (BOOL) hasFetchedHistoryForRoom:(OTRXMPPRoom*)room;
+- (nullable OTRXMPPRoomRuntimeProperties *) runtimePropertiesForRoom:(OTRXMPPRoom*)room;
 
 @end
 NS_ASSUME_NONNULL_END

--- a/ChatSecure/Classes/Model/OTRBuddyCache.m
+++ b/ChatSecure/Classes/Model/OTRBuddyCache.m
@@ -11,6 +11,12 @@
 #import <ChatSecureCore/ChatSecureCore-Swift.h>
 
 @implementation OTRXMPPRoomRuntimeProperties
+- (instancetype)init {
+    if (self = [super init]) {
+        _onlineJids = [NSMutableArray array];
+    }
+    return self;
+}
 @end
 
 @interface OTRBuddyCache() {
@@ -241,6 +247,27 @@
     }];
     return properties;
 }
+
+- (void)setJid:(NSString *)jid online:(BOOL)online inRoom:(OTRXMPPRoom *)room {
+    OTRXMPPRoomRuntimeProperties *properties = [self runtimePropertiesForRoom:room];
+    if (properties) {
+        if (online) {
+            if (![properties.onlineJids containsObject:jid]) {
+                [properties.onlineJids addObject:jid];
+            }
+        } else {
+            if ([properties.onlineJids containsObject:jid]) {
+                [properties.onlineJids removeObject:jid];
+            }
+        }
+    }
+}
+
+- (BOOL)jidOnline:(NSString *)jid inRoom:(OTRXMPPRoom *)room {
+    OTRXMPPRoomRuntimeProperties *properties = [self runtimePropertiesForRoom:room];
+    return (properties && [properties.onlineJids containsObject:jid]);
+}
+
 
 /** Clears everything for given buddies */
 - (void) purgeAllPropertiesForBuddies:(NSArray <OTRBuddy*>*)buddies {

--- a/ChatSecure/Classes/Model/OTRBuddyCache.m
+++ b/ChatSecure/Classes/Model/OTRBuddyCache.m
@@ -10,6 +10,9 @@
 #import "OTRDatabaseManager.h"
 #import <ChatSecureCore/ChatSecureCore-Swift.h>
 
+@implementation OTRXMPPRoomRuntimeProperties
+@end
+
 @interface OTRBuddyCache() {
     void *IsOnInternalQueueKey;
 }
@@ -19,8 +22,7 @@
 @property (nonatomic, strong, readonly) NSMutableDictionary<NSString*,NSDictionary<NSString*, NSNumber*>*> *threadStatuses;
 @property (nonatomic, strong, readonly) NSMutableDictionary<NSString*,NSNumber*> *waitingForvCardTempFetch;
 @property (nonatomic, strong, readonly) NSMutableDictionary<NSString*,NSDate*> *lastSeenDates;
-@property (nonatomic, strong, readonly) NSMutableDictionary<NSString*,NSNumber*> *roomJoinedFlags;
-@property (nonatomic, strong, readonly) NSMutableDictionary<NSString*,NSNumber*> *roomHasFetchedHistoryFlags;
+@property (nonatomic, strong, readonly) NSMutableDictionary<NSString*,OTRXMPPRoomRuntimeProperties*> *roomProperties;
 
 @property (nonatomic, strong, readonly) dispatch_queue_t queue;
 
@@ -50,8 +52,7 @@
         _threadStatuses = [NSMutableDictionary dictionary];
         _waitingForvCardTempFetch = [NSMutableDictionary dictionary];
         _lastSeenDates = [NSMutableDictionary dictionary];
-        _roomJoinedFlags = [NSMutableDictionary dictionary];
-        _roomHasFetchedHistoryFlags = [NSMutableDictionary dictionary];
+        _roomProperties = [NSMutableDictionary dictionary];
     }
     return self;
 }
@@ -225,40 +226,20 @@
     }];
 }
 
-- (void)setJoined:(BOOL)joined forRoom:(OTRXMPPRoom *)room {
+- (OTRXMPPRoomRuntimeProperties *)runtimePropertiesForRoom:(OTRXMPPRoom *)room {
     NSParameterAssert(room.uniqueId);
-    if (!room.uniqueId) { return; }
-    [self performAsyncWrite:^{
-        [self.roomJoinedFlags setObject:@(joined) forKey:room.uniqueId];
-    }];
-}
-
-- (BOOL)joinedForRoom:(OTRXMPPRoom *)room {
-    NSParameterAssert(room.uniqueId);
-    if (!room.uniqueId) { return NO; }
-    __block BOOL joined = NO;
+    if (!room.uniqueId) { return nil; }
+    __block OTRXMPPRoomRuntimeProperties *properties = nil;
     [self performSyncRead:^{
-        joined = [self.roomJoinedFlags objectForKey:room.uniqueId].boolValue;
+        properties = [self.roomProperties objectForKey:room.uniqueId];
+        if (!properties) {
+            properties = [[OTRXMPPRoomRuntimeProperties alloc] init];
+            [self performAsyncWrite:^{
+                [self.roomProperties setObject:properties forKey:room.uniqueId];
+            }];
+        }
     }];
-    return joined;
-}
-
-- (void)setHasFetchedHistory:(BOOL)hasFetchedHistory forRoom:(OTRXMPPRoom *)room {
-    NSParameterAssert(room.uniqueId);
-    if (!room.uniqueId) { return; }
-    [self performAsyncWrite:^{
-        [self.roomHasFetchedHistoryFlags setObject:@(hasFetchedHistory) forKey:room.uniqueId];
-    }];
-}
-
-- (BOOL)hasFetchedHistoryForRoom:(OTRXMPPRoom *)room {
-    NSParameterAssert(room.uniqueId);
-    if (!room.uniqueId) { return NO; }
-    __block BOOL hasFetchedHistory = NO;
-    [self performSyncRead:^{
-        hasFetchedHistory = [self.roomHasFetchedHistoryFlags objectForKey:room.uniqueId].boolValue;
-    }];
-    return hasFetchedHistory;
+    return properties;
 }
 
 /** Clears everything for given buddies */
@@ -296,8 +277,7 @@
     
     [self performAsyncWrite:^{
         [rooms enumerateObjectsUsingBlock:^(OTRXMPPRoom * _Nonnull room, NSUInteger idx, BOOL * _Nonnull stop) {
-            [self.roomJoinedFlags removeObjectForKey:room.uniqueId];
-            [self.roomHasFetchedHistoryFlags removeObjectForKey:room.uniqueId];
+            [self.roomProperties removeObjectForKey:room.uniqueId];
         }];
     }];
 }

--- a/ChatSecure/Classes/Model/Yap Storage/OTRXMPPRoom.swift
+++ b/ChatSecure/Classes/Model/Yap Storage/OTRXMPPRoom.swift
@@ -48,19 +48,19 @@ import YapDatabase.YapDatabaseRelationship
     // Transient properties stored in OTRBuddyCache
     @objc open var joined:Bool {
         get {
-            return OTRBuddyCache.shared.joined(for: self)
+            return OTRBuddyCache.shared.runtimeProperties(for: self)?.joined ?? false
         }
         set (value) {
-            OTRBuddyCache.shared.setJoined(value, for: self)
+            OTRBuddyCache.shared.runtimeProperties(for: self)?.joined = value
         }
     }
     
     @objc open var hasFetchedHistory:Bool {
         get {
-            return OTRBuddyCache.shared.hasFetchedHistory(for: self)
+            return OTRBuddyCache.shared.runtimeProperties(for: self)?.hasFetchedHistory ?? false
         }
         set (value) {
-            OTRBuddyCache.shared.setHasFetchedHistory(value, for: self)
+            OTRBuddyCache.shared.runtimeProperties(for: self)?.hasFetchedHistory = value
         }
     }
     

--- a/ChatSecure/Classes/Model/Yap Storage/OTRXMPPRoomOccupant.swift
+++ b/ChatSecure/Classes/Model/Yap Storage/OTRXMPPRoomOccupant.swift
@@ -93,10 +93,6 @@ open class OTRXMPPRoomOccupant: OTRYapDatabaseObject, YapDatabaseRelationshipNod
     
     @objc open static let roomEdgeName = "OTRRoomOccupantEdgeName"
     
-    @objc open var available:Bool {
-        return (_jids?.count ?? 0) > 0
-    }
-    
     /** This is all JIDs of the participant as it's known in the room i.e. baseball_chat@conference.dukgo.com/user123 */
     @objc private var _jids: [String]?
     
@@ -151,7 +147,7 @@ open class OTRXMPPRoomOccupant: OTRYapDatabaseObject, YapDatabaseRelationshipNod
     }
     
     @objc override open class func storageBehaviorForProperty(withKey key:String) -> MTLPropertyStorage {
-        if key == #keyPath(available) || key == #keyPath(jids) {
+        if key == #keyPath(jids) {
             return MTLPropertyStorageNone
         }
         return super.storageBehaviorForProperty(withKey: key)

--- a/ChatSecure/Classes/View Controllers/OTRRoomOccupantsViewController.swift
+++ b/ChatSecure/Classes/View Controllers/OTRRoomOccupantsViewController.swift
@@ -475,7 +475,11 @@ extension OTRRoomOccupantsViewController: UITableViewDataSource {
                 buddy.username = roomOccupant.realJID ?? roomOccupant.jids.first?.full ?? ""
                 buddy.displayName = roomOccupant.roomName ?? buddy.username
                 var status: OTRThreadStatus = .available
-                if !roomOccupant.available {
+                
+                //Any of the occupants jids online?
+                if !roomOccupant.jids.contains(where: { (jid) -> Bool in
+                    return OTRBuddyCache.shared.jidOnline(jid.full, in: room)
+                }) {
                     status = .offline
                 }
                 OTRBuddyCache.shared.setThreadStatus(status, for: buddy, resource: nil)


### PR DESCRIPTION
Sigh, now after these changes, hanging on to the jid:s, I wonder if we maybe should have sticked to having XMPPRoomOccupant as an occupant and not a container object...  Ah well. Consider this Work In Progress, still stuff to do here, but mostly wanted to see how you like the idea of storing online/offline in the buddy cache (which nowadays is a bit of a misnomer)?

Also in this PR - delay fetching the history until we are done getting room members, admins and owners. Currently really only works in theory since we 1. Use old-school history elements and 2. Fetch MAM history for everything when we connect to the server, so the results will come "too early".