### PR TITLE
Improve Yap connection isolation

### DIFF
--- a/ChatSecure/Classes/Controllers/OTRAccountMigrator.m
+++ b/ChatSecure/Classes/Controllers/OTRAccountMigrator.m
@@ -72,7 +72,7 @@
     self.isMigrationInProgress = YES;
     self.completion = completion;
     NSParameterAssert(completion != nil);
-    [OTRDatabaseManager.shared.readWriteDatabaseConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
+    [OTRDatabaseManager.shared.writeConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
         [self.migratedAccount saveWithTransaction:transaction];
     }];
     if ([self areBothAccountsAreOnline]) {
@@ -107,7 +107,7 @@
     NSMutableArray<id<OTRMessageProtocol>> *outgoingMessages = [NSMutableArray array];
     __block NSArray<OTRXMPPBuddy*> *buddies = @[];
     __block NSMutableArray<OTRBuddy*> *newBuddies = [NSMutableArray array];
-    [[OTRDatabaseManager sharedInstance].readOnlyDatabaseConnection readWithBlock:^(YapDatabaseReadTransaction * _Nonnull transaction) {
+    [[OTRDatabaseManager sharedInstance].uiConnection readWithBlock:^(YapDatabaseReadTransaction * _Nonnull transaction) {
         buddies = [self.oldAccount allBuddiesWithTransaction:transaction];
         newBuddies = [NSMutableArray arrayWithCapacity:buddies.count];
         [buddies enumerateObjectsUsingBlock:^(OTRXMPPBuddy * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
@@ -137,7 +137,7 @@
     }];
     
     
-    [OTRDatabaseManager.shared.readWriteDatabaseConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction * _Nonnull transaction) {
+    [OTRDatabaseManager.shared.writeConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction * _Nonnull transaction) {
         [newBuddies enumerateObjectsUsingBlock:^(OTRBuddy * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
             [obj saveWithTransaction:transaction];
         }];
@@ -162,7 +162,7 @@
     vCard.jid = self.migratedAccount.bareJID;
     self.oldAccount.waitingForvCardTempFetch = NO;
     self.oldAccount.lastUpdatedvCardTemp = [NSDate date];
-    [OTRDatabaseManager.shared.readWriteDatabaseConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction * _Nonnull transaction) {
+    [OTRDatabaseManager.shared.writeConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction * _Nonnull transaction) {
         [self.oldAccount saveWithTransaction:transaction];
     }];
     [oldXmpp.xmppvCardTempModule updateMyvCardTemp:vCard];
@@ -175,7 +175,7 @@
     
     // Step 6 - Mark your old conversations as 'archived'
     
-    [OTRDatabaseManager.shared.readWriteDatabaseConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction * _Nonnull transaction) {
+    [OTRDatabaseManager.shared.writeConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction * _Nonnull transaction) {
         [buddies enumerateObjectsUsingBlock:^(OTRXMPPBuddy * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
             obj = [obj copy];
             obj.isArchived = YES;

--- a/ChatSecure/Classes/Controllers/OTRAccountsManager.m
+++ b/ChatSecure/Classes/Controllers/OTRAccountsManager.m
@@ -37,7 +37,7 @@
     NSParameterAssert(account);
     if (!account) { return; }
     [account removeKeychainPassword:nil];
-    [[OTRDatabaseManager sharedInstance].readWriteDatabaseConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
+    [[OTRDatabaseManager sharedInstance].writeConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
         [transaction removeObjectForKey:account.uniqueId inCollection:[OTRAccount collection]];
     }];
 }
@@ -45,7 +45,7 @@
 + (NSArray<OTRAccount*> *)allAccounts  {
     
     __block NSArray *accounts = @[];
-    [[OTRDatabaseManager sharedInstance].readOnlyDatabaseConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
+    [[OTRDatabaseManager sharedInstance].readConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
         accounts = [OTRAccount allAccountsWithTransaction:transaction];
     }];
     return accounts;
@@ -54,7 +54,7 @@
 + (OTRAccount *)accountWithUsername:(NSString *)username
 {
     __block OTRAccount *account = nil;
-    [[OTRDatabaseManager sharedInstance].readOnlyDatabaseConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
+    [[OTRDatabaseManager sharedInstance].readConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
         account = [[OTRAccount allAccountsWithUsername:username transaction:transaction] firstObject];
     }];
     return account;
@@ -63,7 +63,7 @@
 + (NSArray *)allAutoLoginAccounts
 {
     __block NSArray *accounts = nil;
-    [[OTRDatabaseManager sharedInstance].readOnlyDatabaseConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
+    [[OTRDatabaseManager sharedInstance].readConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
         accounts = [OTRAccount allAccountsWithTransaction:transaction];
     }];
 

--- a/ChatSecure/Classes/Controllers/OTRDatabaseManager.h
+++ b/ChatSecure/Classes/Controllers/OTRDatabaseManager.h
@@ -22,9 +22,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly, nullable) YapDatabase *database;
 @property (nonatomic, strong, nullable) OTRMediaServer *mediaServer;
-@property (nonatomic, readonly, nullable) YapDatabaseConnection *readOnlyDatabaseConnection;
-@property (nonatomic, readonly, nullable) YapDatabaseConnection *readWriteDatabaseConnection;
 
+/// User interface / synchronous main-thread reads only!
+@property (nonatomic, readonly, nullable) YapDatabaseConnection *uiConnection;
+/// Background / async reads only! Not for use in main thread / UI code.
+@property (nonatomic, readonly, nullable) YapDatabaseConnection *readConnection;
+/// Background writes only! Never use this synchronously from the main thread!
+@property (nonatomic, readonly, nullable) YapDatabaseConnection *writeConnection;
+
+/// This is only to be used by the YapViewHandler for main thread reads only!
 @property (nonatomic, readonly, nullable) YapDatabaseConnection *longLivedReadOnlyConnection;
 
 @property (nonatomic, readonly, nullable) MessageQueueHandler *messageQueueHandler;
@@ -42,8 +48,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)setupDatabaseWithName:(NSString*)databaseName
                     directory:(nullable NSString*)directory
                   withMediaStorage:(BOOL)withMediaStorage;
-
-- (nullable YapDatabaseConnection *)newConnection;
 
 - (void)setDatabasePassphrase:(NSString *)passphrase remember:(BOOL)rememeber error:(NSError *_Nullable*)error;
 

--- a/ChatSecure/Classes/Controllers/OTREncryptionManager.h
+++ b/ChatSecure/Classes/Controllers/OTREncryptionManager.h
@@ -48,6 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * This method takes a buddy key and collection. If it finds an object in the database and `hasGoneEncryptedBefore` is true
  * It will try to initiate a new OTR session. This is useful when re-entering a converstaion with a buddy.
+ * This will bail out unless buddy.preferredSecurity == .OTR
  *
  * @param buddyKey The Yap key for the buddy
  * @param collection The Yap collection for the buddy

--- a/ChatSecure/Classes/Controllers/OTROMEMOSignalCoordinator.swift
+++ b/ChatSecure/Classes/Controllers/OTROMEMOSignalCoordinator.swift
@@ -562,6 +562,7 @@ import SignalProtocolObjC
     }
 }
 
+// MARK: - OMEMOModuleDelegate
 extension OTROMEMOSignalCoordinator: OMEMOModuleDelegate {
     
     public func omemo(_ omemo: OMEMOModule, publishedDeviceIds deviceIds: [NSNumber], responseIq: XMPPIQ, outgoingIq: XMPPIQ) {
@@ -662,6 +663,7 @@ extension OTROMEMOSignalCoordinator: OMEMOModuleDelegate {
     }
 }
 
+// MARK: - OMEMOStorageDelegate
 extension OTROMEMOSignalCoordinator:OMEMOStorageDelegate {
     
     public func configure(withParent aParent: OMEMOModule, queue: DispatchQueue) -> Bool {

--- a/ChatSecure/Classes/Controllers/OTRProtocolManager.m
+++ b/ChatSecure/Classes/Controllers/OTRProtocolManager.m
@@ -264,7 +264,7 @@
 
 - (void)sendMessage:(OTROutgoingMessage *)message {
     __block OTRAccount * account = nil;
-    [[OTRDatabaseManager sharedInstance].readOnlyDatabaseConnection asyncReadWithBlock:^(YapDatabaseReadTransaction *transaction) {
+    [OTRDatabaseManager.shared.readConnection asyncReadWithBlock:^(YapDatabaseReadTransaction *transaction) {
         OTRBuddy *buddy = [OTRBuddy fetchObjectWithUniqueID:message.buddyUniqueId transaction:transaction];
         account = [OTRAccount fetchObjectWithUniqueID:buddy.accountUniqueId transaction:transaction];
     } completionBlock:^{
@@ -284,7 +284,7 @@
     }
     UIAlertController *alert = [UIAlertController alertControllerWithTitle:ADD_BUDDY_STRING() message:message preferredStyle:(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone) ? UIAlertControllerStyleActionSheet : UIAlertControllerStyleAlert];
     NSMutableArray<OTRAccount*> *accounts = [NSMutableArray array];
-    [[OTRDatabaseManager sharedInstance].readOnlyDatabaseConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
+    [OTRDatabaseManager.shared.readConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
         NSArray<OTRAccount*> *allAccounts = [OTRAccount allAccountsWithTransaction:transaction];
         [allAccounts enumerateObjectsUsingBlock:^(OTRAccount * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
             if (!obj.isArchived) {

--- a/ChatSecure/Classes/Controllers/OTRSplitViewCoordinator.swift
+++ b/ChatSecure/Classes/Controllers/OTRSplitViewCoordinator.swift
@@ -131,8 +131,8 @@ open class OTRSplitViewCoordinator: NSObject, OTRConversationViewControllerDeleg
         guard splitViewController?.presentedViewController == nil,
         let xmpp = OTRProtocolManager.shared.protocol(for: account) as? XMPPManager,
         let longLivedReadConnection = OTRDatabaseManager.shared.longLivedReadOnlyConnection,
-        let writeConnection =  OTRDatabaseManager.shared.readWriteDatabaseConnection,
-        let read = OTRDatabaseManager.shared.readOnlyDatabaseConnection
+        let writeConnection =  OTRDatabaseManager.shared.writeConnection,
+        let read = OTRDatabaseManager.shared.readConnection
             else {
             return
         }

--- a/ChatSecure/Classes/Controllers/PushController.swift
+++ b/ChatSecure/Classes/Controllers/PushController.swift
@@ -80,7 +80,7 @@ open class PushController: NSObject, OTRPushTLVHandlerDelegate, PushControllerPr
     var pubsubEndpoint: NSString?
     
     @objc public init(baseURL: URL, sessionConfiguration: URLSessionConfiguration, databaseConnection: YapDatabaseConnection? = nil, tlvHandler:OTRPushTLVHandlerProtocol? = nil) {
-        let databaseConnection = databaseConnection ?? OTRDatabaseManager.shared.readWriteDatabaseConnection!
+        let databaseConnection = databaseConnection ?? OTRDatabaseManager.shared.writeConnection!
 
         self.apiClient = Client(baseUrl: baseURL, urlSessionConfiguration: sessionConfiguration, account: nil)
         self.storage = PushStorage(databaseConnection: databaseConnection)

--- a/ChatSecure/Classes/Controllers/XMPP/OTRXMPPManager.m
+++ b/ChatSecure/Classes/Controllers/XMPP/OTRXMPPManager.m
@@ -226,7 +226,7 @@ typedef NS_ENUM(NSInteger, XMPPClientState) {
     _fileTransferManager = [[FileTransferManager alloc] initWithConnection:self.databaseConnection serverCapabilities:self.serverCheck.serverCapabilities sessionConfiguration:sessionConfiguration];
     
     // Message storage
-    RoomStorage *roomStorage = [[RoomStorage alloc] initWithConnection:self.databaseConnection capabilities:self.serverCheck.xmppCapabilities fileTransfer:self.fileTransferManager vCardModule:self.xmppvCardTempModule];
+    RoomStorage *roomStorage = [[RoomStorage alloc] initWithConnection:self.databaseConnection capabilities:self.serverCheck.xmppCapabilities fileTransfer:self.fileTransferManager vCardModule:self.xmppvCardTempModule omemoModule:self.omemoModule];
 
     _messageStorage = [[MessageStorage alloc] initWithConnection:self.databaseConnection
                                                     capabilities:self.serverCheck.xmppCapabilities

--- a/ChatSecure/Classes/Controllers/XMPP/Storage/MessageStorage.swift
+++ b/ChatSecure/Classes/Controllers/XMPP/Storage/MessageStorage.swift
@@ -505,7 +505,7 @@ extension NSCopying {
 public extension MessageStorage {
     @objc public static func markAsReadIfVisible(message: OTRMessageProtocol) {
         guard message.isMessageRead == false,
-            let connection = OTRDatabaseManager.shared.readWriteDatabaseConnection else {
+            let connection = OTRDatabaseManager.shared.writeConnection else {
             return
         }
         OTRAppDelegate.visibleThread({ (ck) in

--- a/ChatSecure/Classes/Controllers/XMPP/Storage/OTRvCardYapDatabaseStorage.m
+++ b/ChatSecure/Classes/Controllers/XMPP/Storage/OTRvCardYapDatabaseStorage.m
@@ -27,7 +27,7 @@
 {
     if (self = [super init]) {
         self.storageQueue = dispatch_queue_create("OTR.OTRvCardYapDatabaseStorage", NULL);
-        self.databaseConnection = [OTRDatabaseManager sharedInstance].readWriteDatabaseConnection;
+        self.databaseConnection = [OTRDatabaseManager sharedInstance].writeConnection;
     }
     return self;
 }
@@ -88,7 +88,7 @@
  **/
 - (void)clearvCardTempForJID:(XMPPJID *)jid xmppStream:(XMPPStream *)stream
 {
-    [[OTRDatabaseManager sharedInstance].readWriteDatabaseConnection asyncReadWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
+    [[OTRDatabaseManager sharedInstance].writeConnection asyncReadWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
         id<OTRvCard> vCard = nil;
         if ([jid isEqualToJID:stream.myJID options:XMPPJIDCompareBare]) {
             vCard = [OTRXMPPAccount accountForStream:stream transaction:transaction];
@@ -140,7 +140,7 @@
  **/
 - (void)setvCardTemp:(XMPPvCardTemp *)vCardTemp forJID:(XMPPJID *)jid xmppStream:(XMPPStream *)stream
 {
-    [[OTRDatabaseManager sharedInstance].readWriteDatabaseConnection asyncReadWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
+    [[OTRDatabaseManager sharedInstance].writeConnection asyncReadWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
         id<OTRvCard> vCard = nil;
         if ([stream.myJID isEqualToJID:jid options:XMPPJIDCompareBare]) {
             vCard = [[OTRXMPPAccount accountForStream:stream transaction:transaction] copy];

--- a/ChatSecure/Classes/Controllers/XMPP/Storage/RoomStorage.swift
+++ b/ChatSecure/Classes/Controllers/XMPP/Storage/RoomStorage.swift
@@ -18,17 +18,20 @@ import YapDatabase
     private let capabilities: XMPPCapabilities
     private let fileTransfer: FileTransferManager
     private let vCardModule: XMPPvCardTempModule
+    private let omemoModule: OMEMOModule
     
     // MARK: Init
     
     @objc public init(connection: YapDatabaseConnection,
                       capabilities: XMPPCapabilities,
                       fileTransfer: FileTransferManager,
-                      vCardModule: XMPPvCardTempModule) {
+                      vCardModule: XMPPvCardTempModule,
+                      omemoModule: OMEMOModule) {
         self.connection = connection
         self.capabilities = capabilities
         self.fileTransfer = fileTransfer
         self.vCardModule = vCardModule
+        self.omemoModule = omemoModule
     }
     
     // MARK: Public
@@ -184,7 +187,10 @@ import YapDatabase
                         DDLogInfo("Created non-roster buddy for room \(realJID) \(room)")
                     }
                     occupant.buddyUniqueId = buddy?.uniqueId
+                    /// Fetch vCard for avatar
                     self.vCardModule.fetchvCardTemp(for: realJID, ignoreStorage: false)
+                    /// Fetch DeviceIds for prepping future OMEMO sessions
+                    self.omemoModule.fetchDeviceIds(for: realJID, elementId: nil)
                 }
                 occupant.save(with: transaction)
             })

--- a/ChatSecure/Classes/Controllers/XMPP/Storage/RoomStorage.swift
+++ b/ChatSecure/Classes/Controllers/XMPP/Storage/RoomStorage.swift
@@ -18,7 +18,8 @@ import YapDatabase
     private let capabilities: XMPPCapabilities
     private let fileTransfer: FileTransferManager
     private let vCardModule: XMPPvCardTempModule
-    private let omemoModule: OMEMOModule
+    /// This is public because of a test-related circular dependency with OTROMEMOSignalCoordinator
+    public var omemoModule: OMEMOModule?
     
     // MARK: Init
     
@@ -26,7 +27,7 @@ import YapDatabase
                       capabilities: XMPPCapabilities,
                       fileTransfer: FileTransferManager,
                       vCardModule: XMPPvCardTempModule,
-                      omemoModule: OMEMOModule) {
+                      omemoModule: OMEMOModule? = nil) {
         self.connection = connection
         self.capabilities = capabilities
         self.fileTransfer = fileTransfer
@@ -190,7 +191,7 @@ import YapDatabase
                     /// Fetch vCard for avatar
                     self.vCardModule.fetchvCardTemp(for: realJID, ignoreStorage: false)
                     /// Fetch DeviceIds for prepping future OMEMO sessions
-                    self.omemoModule.fetchDeviceIds(for: realJID, elementId: nil)
+                    self.omemoModule?.fetchDeviceIds(for: realJID, elementId: nil)
                 }
                 occupant.save(with: transaction)
             })

--- a/ChatSecure/Classes/Controllers/YapDatabase+ChatSecure.swift
+++ b/ChatSecure/Classes/Controllers/YapDatabase+ChatSecure.swift
@@ -9,6 +9,37 @@
 import Foundation
 import YapDatabase
 
+@objc public extension OTRDatabaseManager {
+    @objc var connections: DatabaseConnections? {
+        guard let ui = uiConnection,
+        let read = readConnection,
+        let write = writeConnection,
+            let long = longLivedReadOnlyConnection else {
+                return nil
+        }
+        return DatabaseConnections(ui: ui, read: read, write: write, longLivedRead: long)
+    }
+}
+
+/// This class holds shared references to commonly-needed Yap database connections
+@objcMembers
+public class DatabaseConnections: NSObject {
+    public let ui: YapDatabaseConnection
+    public let read: YapDatabaseConnection
+    public let write: YapDatabaseConnection
+    public let longLivedRead: YapDatabaseConnection
+    
+    init(ui: YapDatabaseConnection,
+    read: YapDatabaseConnection,
+    write: YapDatabaseConnection,
+    longLivedRead: YapDatabaseConnection) {
+        self.ui = ui
+        self.read = read
+        self.write = write
+        self.longLivedRead = longLivedRead
+    }
+}
+
 public extension YapDatabase {
     
      @objc func asyncRegisterView(_ grouping:YapDatabaseViewGrouping, sorting:YapDatabaseViewSorting, version:String, whiteList:Set<String>, name:DatabaseExtensionName, completionQueue:DispatchQueue?, completionBlock:((Bool) ->Void)?) {

--- a/ChatSecure/Classes/Controllers/YapDatabase+ChatSecure.swift
+++ b/ChatSecure/Classes/Controllers/YapDatabase+ChatSecure.swift
@@ -24,9 +24,13 @@ import YapDatabase
 /// This class holds shared references to commonly-needed Yap database connections
 @objcMembers
 public class DatabaseConnections: NSObject {
+    /// User interface / synchronous main-thread reads only!
     public let ui: YapDatabaseConnection
+    /// Background / async reads only! Not for use in main thread / UI code.
     public let read: YapDatabaseConnection
+    /// Background writes only! Never use this synchronously from the main thread!
     public let write: YapDatabaseConnection
+    /// This is only to be used by the YapViewHandler for main thread reads only!
     public let longLivedRead: YapDatabaseConnection
     
     init(ui: YapDatabaseConnection,

--- a/ChatSecure/Classes/Model/MessagesViewControllerState.swift
+++ b/ChatSecure/Classes/Model/MessagesViewControllerState.swift
@@ -14,15 +14,20 @@ import Foundation
     /** This should reflect whether the textview currently has text */
     @objc open var hasText = false
     
-    /** This should reflect if the current thread can send a knock message and therefore show knock UI */
-    @objc open var canKnock = false
-    
-    /** Reflects media messages can be send. Right now OTRData is only supported so based on if OTR session exists */
+    /** Reflects media messages can be sent. */
     @objc open var canSendMedia = false
     
     /** This should reflect how messages should be sent and what the buddy prefrences are */
     @objc open var messageSecurity = OTRMessageTransportSecurity.plaintext
     
-    /** This should reflect if the thread(buddy) is online or not so show knock UI or not. */
+    /** This should reflect if the thread(buddy or room) is online or not. */
     @objc open var isThreadOnline = false
+    
+    /// Resets all state
+    @objc open func reset() {
+        hasText = false
+        canSendMedia = false
+        messageSecurity = .invalid
+        isThreadOnline = false
+    }
 }

--- a/ChatSecure/Classes/Model/OTRBuddyCache.m
+++ b/ChatSecure/Classes/Model/OTRBuddyCache.m
@@ -287,7 +287,7 @@
     }];
     
     [self performAsyncWrite:^{
-        [[OTRDatabaseManager sharedInstance].readWriteDatabaseConnection asyncReadWriteWithBlock:^(YapDatabaseReadWriteTransaction * _Nonnull transaction) {
+        [[OTRDatabaseManager sharedInstance].writeConnection asyncReadWriteWithBlock:^(YapDatabaseReadWriteTransaction * _Nonnull transaction) {
             [buddies enumerateObjectsUsingBlock:^(OTRBuddy * _Nonnull buddy, NSUInteger idx, BOOL * _Nonnull stop) {
                 [self touchBuddy:buddy withTransaction:transaction];
             }];
@@ -319,7 +319,7 @@
 }
 
 - (void) touchBuddy:(OTRBuddy*)buddy {
-    [[OTRDatabaseManager sharedInstance].readWriteDatabaseConnection asyncReadWriteWithBlock:^(YapDatabaseReadWriteTransaction * _Nonnull transaction) {
+    [[OTRDatabaseManager sharedInstance].writeConnection asyncReadWriteWithBlock:^(YapDatabaseReadWriteTransaction * _Nonnull transaction) {
         [self touchBuddy:buddy withTransaction:transaction];
     }];
 }

--- a/ChatSecure/Classes/Model/Yap Storage/OTRMediaItem.m
+++ b/ChatSecure/Classes/Model/Yap Storage/OTRMediaItem.m
@@ -242,7 +242,7 @@ static NSString* GetExtensionForMimeType(NSString* mimeType) {
         // this code is used to fetch the image from the data store and then cache in ram
         __block id<OTRThreadOwner> thread = nil;
         __block id<OTRMessageProtocol> message = nil;
-        [OTRDatabaseManager.shared.readOnlyDatabaseConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
+        [OTRDatabaseManager.shared.readConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
             message = [self parentMessageWithTransaction:transaction];
             thread = [message threadOwnerWithTransaction:transaction];
         }];
@@ -258,7 +258,7 @@ static NSString* GetExtensionForMimeType(NSString* mimeType) {
             DDLogError(@"Could not handle display for media item %@", self);
         } else {
             // Success, touch parent message to display it.
-            [[OTRDatabaseManager sharedInstance].readWriteDatabaseConnection asyncReadWriteWithBlock:^(YapDatabaseReadWriteTransaction * _Nonnull transaction) {
+            [[OTRDatabaseManager sharedInstance].writeConnection asyncReadWriteWithBlock:^(YapDatabaseReadWriteTransaction * _Nonnull transaction) {
                 [self touchParentMessageWithTransaction:transaction];
             }];
         }
@@ -275,7 +275,7 @@ static NSString* GetExtensionForMimeType(NSString* mimeType) {
 /** ⚠️ Do not call from within an existing database transaction */
 - (nullable id<OTRDownloadMessage>) downloadMessage {
     __block id<OTRMessageProtocol> message = nil;
-    [OTRDatabaseManager.shared.readOnlyDatabaseConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
+    [OTRDatabaseManager.shared.uiConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
         message = [self parentMessageWithTransaction:transaction];
     }];
     if ([message conformsToProtocol:@protocol(OTRDownloadMessage)]) {
@@ -332,7 +332,7 @@ static NSString* GetExtensionForMimeType(NSString* mimeType) {
     //#865 Delete File because the parent OTRMessage was deleted
     __block id<OTRThreadOwner> thread = nil;
     __block id<OTRMessageProtocol> message = nil;
-    [OTRDatabaseManager.shared.readOnlyDatabaseConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
+    [OTRDatabaseManager.shared.readConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
         message = [self parentMessageWithTransaction:transaction];
         thread = [message threadOwnerWithTransaction:transaction];
     }];

--- a/ChatSecure/Classes/Model/Yap Storage/OTRMessage+JSQMessageData.m
+++ b/ChatSecure/Classes/Model/Yap Storage/OTRMessage+JSQMessageData.m
@@ -30,7 +30,7 @@
 - (id<JSQMessageMediaData>)media
 {
     __block id <JSQMessageMediaData>media = nil;
-    [[OTRDatabaseManager sharedInstance].readOnlyDatabaseConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
+    [[OTRDatabaseManager sharedInstance].uiConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
         media = [OTRMediaItem fetchObjectWithUniqueID:self.mediaItemUniqueId transaction:transaction];
     }];
     return media;
@@ -41,7 +41,7 @@
     if (self.isMessageIncoming) {
         sender = self.buddyUniqueId;
     } else {
-        [[OTRDatabaseManager sharedInstance].readOnlyDatabaseConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
+        [[OTRDatabaseManager sharedInstance].uiConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
             OTRBuddy *buddy = (OTRBuddy *)[self threadOwnerWithTransaction:transaction];
             OTRAccount *account = [buddy accountWithTransaction:transaction];
             sender = account.uniqueId;
@@ -53,7 +53,7 @@
 - (NSString *)senderDisplayName {
     __block NSString *sender = @"";
     if (self.isMessageIncoming) {
-        [[OTRDatabaseManager sharedInstance].readOnlyDatabaseConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
+        [[OTRDatabaseManager sharedInstance].uiConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
             OTRBuddy *buddy = (OTRBuddy *)[self threadOwnerWithTransaction:transaction];
             if ([buddy.displayName length]) {
                 sender = buddy.displayName;
@@ -63,7 +63,7 @@
             }
         }];
     } else {
-        [[OTRDatabaseManager sharedInstance].readOnlyDatabaseConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
+        [[OTRDatabaseManager sharedInstance].uiConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
             OTRBuddy *buddy = (OTRBuddy *)[self threadOwnerWithTransaction:transaction];
             OTRAccount *account = [buddy accountWithTransaction:transaction];
             if ([account.displayName length]) {

--- a/ChatSecure/Classes/Model/Yap Storage/OTRVideoItem.m
+++ b/ChatSecure/Classes/Model/Yap Storage/OTRVideoItem.m
@@ -39,7 +39,7 @@
 - (NSURL *)mediaURL
 {
     __block NSString *buddyUniqueId = nil;
-    [[OTRDatabaseManager sharedInstance].readOnlyDatabaseConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
+    [[OTRDatabaseManager sharedInstance].uiConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
         id<OTRMessageProtocol> message = [self parentMessageWithTransaction:transaction];
         id<OTRThreadOwner> thread = [message threadOwnerWithTransaction:transaction];
         buddyUniqueId = [thread threadIdentifier];
@@ -76,7 +76,7 @@
         CGImageRelease(imageRef);
         if (image && !error) {
             [OTRImages setImage:image forIdentifier:self.uniqueId];
-            [[OTRDatabaseManager sharedInstance].readWriteDatabaseConnection asyncReadWriteWithBlock:^(YapDatabaseReadWriteTransaction * _Nonnull transaction) {
+            [[OTRDatabaseManager sharedInstance].writeConnection asyncReadWriteWithBlock:^(YapDatabaseReadWriteTransaction * _Nonnull transaction) {
                 [self touchParentMessageWithTransaction:transaction];
             }];
         }

--- a/ChatSecure/Classes/Model/Yap Storage/OTRXMPPRoomMessage.swift
+++ b/ChatSecure/Classes/Model/Yap Storage/OTRXMPPRoomMessage.swift
@@ -384,7 +384,7 @@ extension OTRXMPPRoomMessage:JSQMessageData {
     
     public func senderId() -> String! {
         var result:String? = nil
-        OTRDatabaseManager.sharedInstance().readOnlyDatabaseConnection?.read { (transaction) -> Void in
+        OTRDatabaseManager.sharedInstance().uiConnection?.read { (transaction) -> Void in
             if (self.state.incoming()) {
                 result = self.senderJID
             } else {
@@ -432,7 +432,7 @@ extension OTRXMPPRoomMessage:JSQMessageData {
             return nil
         }
         var media: JSQMessageMediaData? = nil
-        OTRDatabaseManager.shared.readOnlyDatabaseConnection?.read({ (transaction) in
+        OTRDatabaseManager.shared.uiConnection?.read({ (transaction) in
             media = OTRMediaItem.fetchObject(withUniqueID: mediaId, transaction: transaction)
         })
         return media

--- a/ChatSecure/Classes/Model/Yap Storage/PushMessage.swift
+++ b/ChatSecure/Classes/Model/Yap Storage/PushMessage.swift
@@ -159,7 +159,7 @@ extension PushMessage: YapDatabaseRelationshipNode {
 extension PushMessage {
     func account() -> OTRAccount? {
         var account:OTRAccount? = nil
-        OTRDatabaseManager.sharedInstance().readOnlyDatabaseConnection?.read { (transaction) -> Void in
+        OTRDatabaseManager.sharedInstance().uiConnection?.read { (transaction) -> Void in
             if let buddyKey = self.buddyKey {
                 if let buddy = OTRBuddy.fetchObject(withUniqueID: buddyKey, transaction: transaction) {
                     account = buddy.account(with: transaction)

--- a/ChatSecure/Classes/Model/Yap Storage/YapActions/BuddyActions.swift
+++ b/ChatSecure/Classes/Model/Yap Storage/YapActions/BuddyActions.swift
@@ -38,7 +38,7 @@ open class BuddyAction: OTRYapDatabaseObject, YapActionable {
         case .delete:
             let action = YapActionItem(identifier:"delete", date: nil, retryTimeout: 30, requiresInternet: true, block: { (collection, key, object, metadata) -> Void in
                 
-                guard let connection = OTRDatabaseManager.sharedInstance().readWriteDatabaseConnection else {
+                guard let connection = OTRDatabaseManager.sharedInstance().writeConnection else {
                     return
                 }
                 

--- a/ChatSecure/Classes/OTRAppDelegate.m
+++ b/ChatSecure/Classes/OTRAppDelegate.m
@@ -123,7 +123,7 @@
         if ([[[NSProcessInfo processInfo] environment][@"OTRLaunchMode"] isEqualToString:@"ChatSecureUITestsDemoData"]) {
             [OTRChatDemo loadDemoChatInDatabase];
         } else if ([[[NSProcessInfo processInfo] environment][@"OTRLaunchMode"] isEqualToString:@"ChatSecureUITests"]) {
-            [[OTRDatabaseManager sharedInstance].readWriteDatabaseConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction * _Nonnull transaction) {
+            [[OTRDatabaseManager sharedInstance].writeConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction * _Nonnull transaction) {
                 [transaction removeAllObjectsInAllCollections];
             }];
         }
@@ -217,7 +217,7 @@
 - (UIViewController *)setupDefaultSplitViewControllerWithLeadingViewController:(nonnull UIViewController *)leadingViewController
 {
     
-    YapDatabaseConnection *connection = [OTRDatabaseManager sharedInstance].readWriteDatabaseConnection;
+    YapDatabaseConnection *connection = [OTRDatabaseManager sharedInstance].writeConnection;
     _splitViewCoordinator = [[OTRSplitViewCoordinator alloc] initWithDatabaseConnection:connection];
     self.splitViewControllerDelegate = [[OTRSplitViewControllerDelegateObject alloc] init];
     self.conversationViewController.delegate = self.splitViewCoordinator;
@@ -262,7 +262,7 @@
     NSAssert(self.backgroundTask == UIBackgroundTaskInvalid, nil);
     
     __block NSUInteger unread = 0;
-    [[OTRDatabaseManager sharedInstance].readOnlyDatabaseConnection asyncReadWithBlock:^(YapDatabaseReadTransaction *transaction) {
+    [[OTRDatabaseManager sharedInstance].readConnection asyncReadWithBlock:^(YapDatabaseReadTransaction *transaction) {
         unread = [transaction numberOfUnreadMessages];
     } completionBlock:^{
         application.applicationIconBadgeNumber = unread;

--- a/ChatSecure/Classes/OTRAppDelegate.swift
+++ b/ChatSecure/Classes/OTRAppDelegate.swift
@@ -67,7 +67,7 @@ public extension OTRAppDelegate {
     
     /// Temporary hack to fix corrupted development database. Empty incoming MAM messages were stored as unread
     @objc public func fixUnreadMessageCount(_ completion: ((_ unread: UInt) -> Void)?) {
-        OTRDatabaseManager.shared.readWriteDatabaseConnection?.asyncReadWrite({ (transaction) in
+        OTRDatabaseManager.shared.writeConnection?.asyncReadWrite({ (transaction) in
             var messagesToRemove: [OTRIncomingMessage] = []
             var messagesToMarkAsRead: [OTRIncomingMessage] = []
             transaction.enumerateUnreadMessages({ (message, stop) in
@@ -95,7 +95,7 @@ public extension OTRAppDelegate {
             })
         }, completionBlock: {
             var unread: UInt = 0
-            OTRDatabaseManager.shared.readWriteDatabaseConnection?.asyncRead({ (transaction) in
+            OTRDatabaseManager.shared.writeConnection?.asyncRead({ (transaction) in
                 unread = transaction.numberOfUnreadMessages()
             }, completionBlock: {
                 completion?(unread)
@@ -105,7 +105,7 @@ public extension OTRAppDelegate {
     
     @objc public func enterThread(key: String, collection: String) {
         var thread: OTRThreadOwner?
-        OTRDatabaseManager.shared.readOnlyDatabaseConnection?.read({ (transaction) in
+        OTRDatabaseManager.shared.uiConnection?.read({ (transaction) in
             thread = transaction.object(forKey: key, inCollection: collection) as? OTRThreadOwner
         })
         if let thread = thread {
@@ -145,7 +145,7 @@ extension OTRAppDelegate: UNUserNotificationCenterDelegate {
             return nil
         }
         var account: OTRXMPPAccount?
-        OTRDatabaseManager.shared.readOnlyDatabaseConnection?.read({ (transaction) in
+        OTRDatabaseManager.shared.uiConnection?.read({ (transaction) in
             account = OTRXMPPAccount.fetchObject(withUniqueID: accountKey, transaction: transaction)
         })
         return account

--- a/ChatSecure/Classes/Utilities/OTRChatDemo.m
+++ b/ChatSecure/Classes/Utilities/OTRChatDemo.m
@@ -34,7 +34,7 @@
                             @"Merhaba",@"مرحبا",
                             @"Olá"];
     
-    [[OTRDatabaseManager sharedInstance].readWriteDatabaseConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
+    [[OTRDatabaseManager sharedInstance].writeConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
         
         [transaction removeAllObjectsInAllCollections];
         
@@ -113,7 +113,7 @@
 }
 
 + (void)loadPerformanceTestChatsInDatabase {
-    [[OTRDatabaseManager sharedInstance].readWriteDatabaseConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
+    [[OTRDatabaseManager sharedInstance].writeConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
         
         [transaction removeAllObjectsInAllCollections];
         
@@ -172,7 +172,7 @@
 }
 
 + (void)addDummyMessagesForExistingAccount:(NSString*)accountJid toFromBuddy:(NSString*)buddyJid count:(int)count {
-    [[OTRDatabaseManager sharedInstance].readWriteDatabaseConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
+    [[OTRDatabaseManager sharedInstance].writeConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
         
         OTRXMPPAccount *account = (OTRXMPPAccount *)[[OTRXMPPAccount allAccountsWithUsername:accountJid transaction:transaction] firstObject];
         if (!account) {return;}

--- a/ChatSecure/Classes/Utilities/OTRUtilities.m
+++ b/ChatSecure/Classes/Utilities/OTRUtilities.m
@@ -74,7 +74,7 @@
 
 +(void)deleteAllBuddiesAndMessages
 {
-    [[OTRDatabaseManager sharedInstance].readWriteDatabaseConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
+    [[OTRDatabaseManager sharedInstance].writeConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
         [transaction removeAllObjectsInCollection:[OTRBuddy collection]];
         [transaction removeAllObjectsInCollection:[OTRBaseMessage collection]];
     }];
@@ -82,7 +82,7 @@
 
 + (void)deleteAccountsWithoutUsername
 {
-    [[OTRDatabaseManager sharedInstance].readWriteDatabaseConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
+    [[OTRDatabaseManager sharedInstance].writeConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
         NSMutableArray *deleteKeys = [NSMutableArray array];
         [transaction enumerateKeysAndObjectsInCollection:[OTRAccount collection] usingBlock:^(NSString *key, OTRAccount *account, BOOL *stop) {
             if (![account.username length]) {

--- a/ChatSecure/Classes/View Controllers/KeyManagementViewController.swift
+++ b/ChatSecure/Classes/View Controllers/KeyManagementViewController.swift
@@ -86,7 +86,7 @@ open class KeyManagementViewController: XLFormViewController {
                 break
             }
         }
-        OTRDatabaseManager.sharedInstance().readWriteDatabaseConnection?.asyncReadWrite({ (t: YapDatabaseReadWriteTransaction) in
+        OTRDatabaseManager.sharedInstance().writeConnection?.asyncReadWrite({ (t: YapDatabaseReadWriteTransaction) in
             for viewedDevice in devicesToSave {
                 if var device = t.object(forKey: viewedDevice.uniqueId, inCollection: OMEMODevice.collection) as? OMEMODevice {
                     device = device.copy() as! OMEMODevice
@@ -247,7 +247,7 @@ open class KeyManagementViewController: XLFormViewController {
                 preferredSecurity = .plaintextWithOTR
             }
             
-            OTRDatabaseManager.sharedInstance().readWriteDatabaseConnection?.readWrite({ (transaction: YapDatabaseReadWriteTransaction) in
+            OTRDatabaseManager.sharedInstance().writeConnection?.readWrite({ (transaction: YapDatabaseReadWriteTransaction) in
                 guard var buddy = transaction.object(forKey: buddy.uniqueId, inCollection: type(of: buddy).collection) as? OTRBuddy else {
                     return
                 }

--- a/ChatSecure/Classes/View Controllers/Login View Controllers/OTRBaseLoginViewController.m
+++ b/ChatSecure/Classes/View Controllers/Login View Controllers/OTRBaseLoginViewController.m
@@ -113,7 +113,7 @@ static NSUInteger kOTRMaxLoginAttempts = 5;
                     // the account is never saved. If the account is never
                     // saved, it's impossible to delete the orphaned password
                     __block BOOL accountExists = NO;
-                    [[OTRDatabaseManager sharedInstance].readOnlyDatabaseConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
+                    [[OTRDatabaseManager sharedInstance].uiConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
                         accountExists = [transaction objectForKey:account.uniqueId inCollection:[[OTRAccount class] collection]] != nil;
                     }];
                     if (!accountExists) {
@@ -131,7 +131,7 @@ static NSUInteger kOTRMaxLoginAttempts = 5;
 - (void) handleSuccessWithNewAccount:(OTRAccount*)account sender:(id)sender {
     NSParameterAssert(account != nil);
     if (!account) { return; }
-    [[OTRDatabaseManager sharedInstance].readWriteDatabaseConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
+    [[OTRDatabaseManager sharedInstance].writeConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
         [account saveWithTransaction:transaction];
     }];
     

--- a/ChatSecure/Classes/View Controllers/Login View Controllers/OTRExistingAccountViewController.m
+++ b/ChatSecure/Classes/View Controllers/Login View Controllers/OTRExistingAccountViewController.m
@@ -113,7 +113,7 @@
                 OTRGoogleOAuthXMPPAccount *googleAccount = [[OTRGoogleOAuthXMPPAccount alloc] initWithUsername:auth.userEmail accountType:OTRAccountTypeGoogleTalk];
                 googleAccount.oAuthTokenDictionary = auth.parameters;
                 
-                [[OTRDatabaseManager sharedInstance].readWriteDatabaseConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
+                [[OTRDatabaseManager sharedInstance].writeConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
                     [googleAccount saveWithTransaction:transaction];
                 }];
                 

--- a/ChatSecure/Classes/View Controllers/OTRBuddyViewController.m
+++ b/ChatSecure/Classes/View Controllers/OTRBuddyViewController.m
@@ -37,7 +37,7 @@
 {
     if(self = [self init])
     {
-        [[OTRDatabaseManager sharedInstance].readOnlyDatabaseConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
+        [[OTRDatabaseManager sharedInstance].uiConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
             self.buddy = [OTRBuddy fetchObjectWithUniqueID:buddyID transaction:transaction];
             self.account = [self.buddy accountWithTransaction:transaction];
             isXMPPAccount = [[self.account protocolClass] isSubclassOfClass:[OTRXMPPManager class]];

--- a/ChatSecure/Classes/View Controllers/OTRComposeGroupViewController.swift
+++ b/ChatSecure/Classes/View Controllers/OTRComposeGroupViewController.swift
@@ -102,7 +102,7 @@ open class OTRComposeGroupViewController: UIViewController, UICollectionViewDele
 
     open func filterOnAccount(accountUniqueId:String?) {
         // Setup filtering to only show default account!
-        OTRDatabaseManager.shared.readWriteDatabaseConnection?.readWrite({ (transaction) in
+        OTRDatabaseManager.shared.writeConnection?.readWrite({ (transaction) in
             if let fvt = transaction.ext(OTRArchiveFilteredBuddiesName) as? YapDatabaseFilteredViewTransaction {
                 let filtering = YapDatabaseViewFiltering.withObjectBlock { (transaction, group, collection, key, object) -> Bool in
                     if let accountId = accountUniqueId, let buddy = object as? OTRXMPPBuddy {
@@ -155,7 +155,7 @@ open class OTRComposeGroupViewController: UIViewController, UICollectionViewDele
         if let cell = tableView.dequeueReusableCell(withIdentifier: OTRBuddyInfoCheckableCell.reuseIdentifier(), for: indexPath) as? OTRBuddyInfoCheckableCell,
             let threadOwner = self.viewHandler?.object(indexPath) as? OTRXMPPBuddy {
             var account:OTRAccount? = nil
-            OTRDatabaseManager.shared.readOnlyDatabaseConnection?.read({ (transaction) in
+            OTRDatabaseManager.shared.uiConnection?.read({ (transaction) in
                 if self.shouldShowAccountLabelWithTransaction(transaction: transaction) {
                     account = OTRAccount(forThread: threadOwner, transaction: transaction)
                 }
@@ -224,7 +224,7 @@ open class OTRComposeGroupViewController: UIViewController, UICollectionViewDele
                     for row in 0..<mappings.numberOfItems(inSection: section) {
                         var buddy:OTRXMPPBuddy? = nil
                         if let roomOccupant = viewHandler.object(IndexPath(row: Int(row), section: Int(section))) as? OTRXMPPRoomOccupant {
-                            OTRDatabaseManager.shared.readOnlyDatabaseConnection?.read({ (transaction) in
+                            OTRDatabaseManager.shared.uiConnection?.read({ (transaction) in
                                 buddy = roomOccupant.buddy(with: transaction)
                             })
                             if let buddy = buddy {

--- a/ChatSecure/Classes/View Controllers/OTRComposeViewController.m
+++ b/ChatSecure/Classes/View Controllers/OTRComposeViewController.m
@@ -53,7 +53,7 @@
     if (self = [super init]) {
         self.selectedBuddiesIdSet = [[NSMutableSet alloc] init];
         _database = [OTRDatabaseManager sharedInstance].database;
-        _readWriteConnection = [OTRDatabaseManager sharedInstance].readWriteDatabaseConnection;
+        _readWriteConnection = [OTRDatabaseManager sharedInstance].writeConnection;
         _searchConnection = [self.database newConnection];
         _searchConnection.name = @"ComposeViewSearchConnection";
         _searchQueue = [[YapDatabaseSearchQueue alloc] init];
@@ -205,7 +205,7 @@
 }
 
 - (void) updateInboxArchiveFilteringAndShowArchived:(BOOL)showArchived {
-    [[OTRDatabaseManager sharedInstance].readWriteDatabaseConnection asyncReadWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
+    [[OTRDatabaseManager sharedInstance].writeConnection asyncReadWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
         YapDatabaseFilteredViewTransaction *fvt = [transaction ext:OTRArchiveFilteredBuddiesName];
         YapDatabaseViewFiltering *filtering = [self getFilteringBlock:showArchived];
         [fvt setFiltering:filtering versionTag:[NSUUID UUID].UUIDString];
@@ -446,7 +446,7 @@
     id<OTRThreadOwner> threadOwner = [self threadOwnerAtIndexPath:indexPath withTableView:tableView];
     
     __block OTRAccount *account = nil;
-    [OTRDatabaseManager.shared.readOnlyDatabaseConnection readWithBlock:^(YapDatabaseReadTransaction * _Nonnull transaction) {
+    [OTRDatabaseManager.shared.uiConnection readWithBlock:^(YapDatabaseReadTransaction * _Nonnull transaction) {
         BOOL showAccount = [self shouldShowAccountLabelWithTransaction:transaction];
         if (showAccount) {
             account = [OTRAccount accountForThread:threadOwner transaction:transaction];
@@ -507,7 +507,7 @@
     NSIndexPath *databaseIndexPath = [NSIndexPath indexPathForRow:indexPath.row inSection:0];
     id <OTRThreadOwner> thread = [self threadOwnerAtIndexPath:databaseIndexPath withTableView:tableView];
     if (!thread) { return nil; }
-    return [UITableView editActionsForThread:thread deleteActionAlsoRemovesFromRoster:YES connection:OTRDatabaseManager.shared.readWriteDatabaseConnection];
+    return [UITableView editActionsForThread:thread deleteActionAlsoRemovesFromRoster:YES connection:OTRDatabaseManager.shared.writeConnection];
 }
 
 - (void)addBuddy:(NSArray *)accountsAbleToAddBuddies

--- a/ChatSecure/Classes/View Controllers/OTRMessagesHoldTalkViewController.m
+++ b/ChatSecure/Classes/View Controllers/OTRMessagesHoldTalkViewController.m
@@ -180,7 +180,7 @@ static Float64 kOTRMessagesMinimumAudioTime = .5;
 
 - (void)isTyping {
     __weak __typeof__(self) weakSelf = self;
-    [self.readConnection asyncReadWithBlock:^(YapDatabaseReadTransaction * _Nonnull transaction) {
+    [self.connections.read asyncReadWithBlock:^(YapDatabaseReadTransaction * _Nonnull transaction) {
         __typeof__(self) strongSelf = weakSelf;
         OTRXMPPManager *xmppManager = [strongSelf xmppManagerWithTransaction:transaction];
         [xmppManager sendChatState:OTRChatStateComposing withBuddyID:[strongSelf threadKey]];
@@ -191,7 +191,7 @@ static Float64 kOTRMessagesMinimumAudioTime = .5;
 
 - (void)didFinishTyping {
     __weak __typeof__(self) weakSelf = self;
-    [self.readConnection asyncReadWithBlock:^(YapDatabaseReadTransaction * _Nonnull transaction) {
+    [self.connections.read asyncReadWithBlock:^(YapDatabaseReadTransaction * _Nonnull transaction) {
         __typeof__(self) strongSelf = weakSelf;
         OTRXMPPManager *xmppManager = [strongSelf xmppManagerWithTransaction:transaction];
         [xmppManager sendChatState:OTRChatStateActive withBuddyID:[strongSelf threadKey]];

--- a/ChatSecure/Classes/View Controllers/OTRMessagesHoldTalkViewController.m
+++ b/ChatSecure/Classes/View Controllers/OTRMessagesHoldTalkViewController.m
@@ -180,7 +180,7 @@ static Float64 kOTRMessagesMinimumAudioTime = .5;
 
 - (void)isTyping {
     __weak __typeof__(self) weakSelf = self;
-    [self.readOnlyDatabaseConnection asyncReadWithBlock:^(YapDatabaseReadTransaction * _Nonnull transaction) {
+    [self.readConnection asyncReadWithBlock:^(YapDatabaseReadTransaction * _Nonnull transaction) {
         __typeof__(self) strongSelf = weakSelf;
         OTRXMPPManager *xmppManager = [strongSelf xmppManagerWithTransaction:transaction];
         [xmppManager sendChatState:OTRChatStateComposing withBuddyID:[strongSelf threadKey]];
@@ -191,7 +191,7 @@ static Float64 kOTRMessagesMinimumAudioTime = .5;
 
 - (void)didFinishTyping {
     __weak __typeof__(self) weakSelf = self;
-    [self.readOnlyDatabaseConnection asyncReadWithBlock:^(YapDatabaseReadTransaction * _Nonnull transaction) {
+    [self.readConnection asyncReadWithBlock:^(YapDatabaseReadTransaction * _Nonnull transaction) {
         __typeof__(self) strongSelf = weakSelf;
         OTRXMPPManager *xmppManager = [strongSelf xmppManagerWithTransaction:transaction];
         [xmppManager sendChatState:OTRChatStateActive withBuddyID:[strongSelf threadKey]];

--- a/ChatSecure/Classes/View Controllers/OTRMessagesViewController.h
+++ b/ChatSecure/Classes/View Controllers/OTRMessagesViewController.h
@@ -26,8 +26,9 @@
 
 @interface OTRMessagesViewController : JSQMessagesViewController <OTRMessagesViewControllerProtocol, UIPopoverPresentationControllerDelegate>
 
-@property (nonatomic, strong, nonnull) YapDatabaseConnection *readOnlyDatabaseConnection;
-@property (nonatomic, strong, nonnull) YapDatabaseConnection *readWriteDatabaseConnection;
+@property (nonatomic, strong, nonnull) YapDatabaseConnection *uiConnection;
+@property (nonatomic, strong, nonnull) YapDatabaseConnection *readConnection;
+@property (nonatomic, strong, nonnull) YapDatabaseConnection *writeConnection;
 @property (nonatomic, strong, nullable) NSString *threadKey;
 @property (nonatomic, strong, nullable) NSString *threadCollection;
 @property (nonatomic, strong, nullable) UIButton *microphoneButton;

--- a/ChatSecure/Classes/View Controllers/OTRMessagesViewController.h
+++ b/ChatSecure/Classes/View Controllers/OTRMessagesViewController.h
@@ -13,7 +13,7 @@
 @import OTRKit;
 @import JSQMessagesViewController;
 
-@class OTRBuddy, OTRXMPPManager, OTRXMPPRoom, OTRXMPPAccount, YapDatabaseConnection, OTRYapDatabaseObject, MessagesViewControllerState;
+@class OTRBuddy, OTRXMPPManager, OTRXMPPRoom, OTRXMPPAccount, YapDatabaseConnection, OTRYapDatabaseObject, MessagesViewControllerState, DatabaseConnections;
 
 @protocol OTRThreadOwner,OTRMessageProtocol,JSQMessageData;
 
@@ -26,9 +26,10 @@
 
 @interface OTRMessagesViewController : JSQMessagesViewController <OTRMessagesViewControllerProtocol, UIPopoverPresentationControllerDelegate>
 
-@property (nonatomic, strong, nonnull) YapDatabaseConnection *uiConnection;
-@property (nonatomic, strong, nonnull) YapDatabaseConnection *readConnection;
-@property (nonatomic, strong, nonnull) YapDatabaseConnection *writeConnection;
+@property (nonatomic, readonly, nullable) DatabaseConnections *connections;
+@property (nonatomic, strong, readonly, nullable) YapDatabaseConnection *uiConnection DEPRECATED_MSG_ATTRIBUTE("Use connections.ui instead");
+@property (nonatomic, strong, readonly, nullable) YapDatabaseConnection *readConnection DEPRECATED_MSG_ATTRIBUTE("Use connections.read instead");
+@property (nonatomic, strong, readonly, nullable) YapDatabaseConnection *writeConnection DEPRECATED_MSG_ATTRIBUTE("Use connections.write instead");
 @property (nonatomic, strong, nullable) NSString *threadKey;
 @property (nonatomic, strong, nullable) NSString *threadCollection;
 @property (nonatomic, strong, nullable) UIButton *microphoneButton;

--- a/ChatSecure/Classes/View Controllers/OTRNewBuddyViewController.m
+++ b/ChatSecure/Classes/View Controllers/OTRNewBuddyViewController.m
@@ -37,7 +37,7 @@
     
     if (self = [super init]) {
         
-        [[OTRDatabaseManager sharedInstance].readOnlyDatabaseConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
+        [[OTRDatabaseManager sharedInstance].uiConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
             self.account = [OTRAccount fetchObjectWithUniqueID:accountId transaction:transaction];
         }];
     }

--- a/ChatSecure/Classes/View Controllers/OTRRoomOccupantsViewController.swift
+++ b/ChatSecure/Classes/View Controllers/OTRRoomOccupantsViewController.swift
@@ -68,9 +68,9 @@ open class OTRRoomOccupantsViewController: UIViewController {
     open var footerRows:[String] = []
     
     /// for reads only
-    fileprivate let readConnection = OTRDatabaseManager.shared.readOnlyDatabaseConnection
+    fileprivate let readConnection = OTRDatabaseManager.shared.uiConnection
     /// for reads and writes
-    private let connection = OTRDatabaseManager.shared.readWriteDatabaseConnection
+    private let connection = OTRDatabaseManager.shared.writeConnection
     open var crownImage:UIImage?
     
     

--- a/ChatSecure/Classes/View Controllers/OTRSettingsViewController.m
+++ b/ChatSecure/Classes/View Controllers/OTRSettingsViewController.m
@@ -324,7 +324,7 @@ static NSString *const kSettingsCellIdentifier = @"kSettingsCellIdentifier";
         xmpp = (OTRXMPPManager*)protocol;
     }
     OTRAccountDetailViewController *detailVC = [[OTRAppDelegate appDelegate].theme accountDetailViewControllerForAccount:account xmpp:xmpp longLivedReadConnection:[OTRDatabaseManager sharedInstance].longLivedReadOnlyConnection
-                                                                                                          readConnection:[OTRDatabaseManager sharedInstance].readOnlyDatabaseConnection writeConnection:[OTRDatabaseManager sharedInstance].readWriteDatabaseConnection];
+                                                                                                          readConnection:[OTRDatabaseManager sharedInstance].readConnection writeConnection:[OTRDatabaseManager sharedInstance].writeConnection];
     UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:detailVC];
     navigationController.modalPresentationStyle = UIModalPresentationFormSheet;
     [self presentViewController:navigationController animated:YES completion:nil];

--- a/ChatSecure/Classes/Views/Cells/MediaDownloadView.swift
+++ b/ChatSecure/Classes/Views/Cells/MediaDownloadView.swift
@@ -53,7 +53,7 @@ public class MediaDownloadView: UIView {
         self.downloadAction = { [weak self] view, sender in
             self?.downloadButton.isEnabled = false
             var xmpp: XMPPManager? = nil
-            OTRDatabaseManager.shared.readOnlyDatabaseConnection?.read { transaction in
+            OTRDatabaseManager.shared.uiConnection?.read { transaction in
                 guard let thread = message.threadOwner(with: transaction) else { return }
                 guard let account = thread.account(with: transaction) else { return }
                 xmpp = OTRProtocolManager.shared.protocol(for: account) as? XMPPManager

--- a/ChatSecure/Classes/Views/Cells/OTRConversationCell.m
+++ b/ChatSecure/Classes/Views/Cells/OTRConversationCell.m
@@ -92,7 +92,7 @@
     /// this is so we can show who sent a group message
     __block OTRXMPPBuddy *groupBuddy = nil;
     
-    [[OTRDatabaseManager sharedInstance].readOnlyDatabaseConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
+    [[OTRDatabaseManager sharedInstance].uiConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
         account = [transaction objectForKey:[thread threadAccountIdentifier] inCollection:[OTRAccount collection]];
         unreadMessages = [thread numberOfUnreadMessagesWithTransaction:transaction];
         lastMessage = [thread lastMessageWithTransaction:transaction];

--- a/ChatSecureTests/OTROMEMOIntegrationTest.swift
+++ b/ChatSecureTests/OTROMEMOIntegrationTest.swift
@@ -167,7 +167,7 @@ class OTROMEMOIntegrationTest: XCTestCase {
         })
         self.bobUser?.signalOMEMOCoordinator.removeDevice([device], completion: { (result) in
             XCTAssertTrue(result)
-            self.bobUser!.databaseManager.uiConnection?.read({ (transaction) in
+            self.bobUser!.databaseManager.readConnection?.read({ (transaction) in
                 let yapKey = OMEMODevice.yapKey(withDeviceId: deviceNumber, parentKey: self.bobUser!.account.uniqueId, parentCollection: OTRAccount.collection)
                 let device = OMEMODevice.fetchObject(withUniqueID: yapKey, transaction: transaction)
                 XCTAssertNil(device)

--- a/ChatSecureTests/OTROmemoStorageTest.swift
+++ b/ChatSecureTests/OTROmemoStorageTest.swift
@@ -17,7 +17,7 @@ extension OTROMEMOSignalCoordinator {
         let file = FileTransferManager(connection: databaseConnection, serverCapabilities: serverCaps, sessionConfiguration: URLSessionConfiguration.ephemeral)
         let vCardStorage = OTRvCardYapDatabaseStorage()
         let vCard = XMPPvCardTempModule(vCardStorage: vCardStorage)
-        let roomStorage = RoomStorage(connection: databaseConnection, capabilities: caps, fileTransfer: file, vCardModule: vCard)
+        let roomStorage = RoomStorage(connection: databaseConnection, capabilities: caps, fileTransfer: file, vCardModule: vCard, omemoModule: nil)
         let messageStorage = MessageStorage(connection: databaseConnection, capabilities: caps, fileTransfer: file, roomStorage: roomStorage)
         let mam = XMPPMessageArchiveManagement()
         let roomManager = OTRXMPPRoomManager(databaseConnection: databaseConnection, roomStorage: roomStorage, archiving: mam, dispatchQueue: nil)

--- a/ChatSecureTests/OTROmemoStorageTest.swift
+++ b/ChatSecureTests/OTROmemoStorageTest.swift
@@ -62,12 +62,12 @@ class OTROmemoStorageTest: XCTestCase {
         let databaseManager = OTRDatabaseManager()
         self.databaseManager = databaseManager
         self.databaseManager?.setupTestDatabase(name: name)
-        self.omemoStorage = OTROMEMOStorageManager(accountKey: accountKey, accountCollection:accountCollection, databaseConnection: databaseManager.readWriteDatabaseConnection!)
+        self.omemoStorage = OTROMEMOStorageManager(accountKey: accountKey, accountCollection:accountCollection, databaseConnection: databaseManager.writeConnection!)
         
-        self.signalStorage = OTRSignalStorageManager(accountKey: accountKey, databaseConnection: databaseManager.readWriteDatabaseConnection!, delegate: nil)
-        self.signalCoordinator = try! OTROMEMOSignalCoordinator(accountYapKey: accountKey, databaseConnection: databaseManager.readWriteDatabaseConnection!)
+        self.signalStorage = OTRSignalStorageManager(accountKey: accountKey, databaseConnection: databaseManager.writeConnection!, delegate: nil)
+        self.signalCoordinator = try! OTROMEMOSignalCoordinator(accountYapKey: accountKey, databaseConnection: databaseManager.writeConnection!)
         
-        databaseManager.readWriteDatabaseConnection?.readWrite( { (transaction) in
+        databaseManager.writeConnection?.readWrite( { (transaction) in
             account.save(with: transaction)
         })
     }

--- a/ChatSecureTests/OTRSignalTest.swift
+++ b/ChatSecureTests/OTRSignalTest.swift
@@ -35,8 +35,8 @@ class OTRSignalTest: XCTestCase {
         let ourAccount = TestXMPPAccount(username: "our.account@something.com", accountType: .jabber)!
         let otherAccount = TestXMPPAccount(username: "other.account@something.com", accountType: .jabber)!
         
-        let ourDatabaseConnection = ourDatabaseManager.newConnection()!
-        let otherDatabaseConnection = otherDatbaseManager.newConnection()!
+        let ourDatabaseConnection = ourDatabaseManager.database!.newConnection()
+        let otherDatabaseConnection = otherDatbaseManager.database!.newConnection()
         
         ourDatabaseConnection.readWrite({ (transaction) in
             ourAccount.save(with:transaction)

--- a/ChatSecureTests/OTRYapViewTest.swift
+++ b/ChatSecureTests/OTRYapViewTest.swift
@@ -66,7 +66,7 @@ class OTRYapViewTest: XCTestCase {
         let delegate = ViewHandlerTestDelegate(didSetup: {
             setupExpecation.fulfill()
             //Once our view handler is ready we need to make a change to the database that will be reflected in the view.
-            self.databaseManager?.readWriteDatabaseConnection?.asyncReadWrite({ (transaction) in
+            self.databaseManager?.writeConnection?.asyncReadWrite({ (transaction) in
                 guard let account = OTRXMPPAccount(username: "account@test.com", accountType: .jabber) else {
                     XCTFail()
                     return


### PR DESCRIPTION
This introduces a `DatabaseConnections` class that encapsulates all of the usually-needed database connections.

```swift
public class DatabaseConnections: NSObject {
    /// User interface / synchronous main-thread reads only!
    public let ui: YapDatabaseConnection
    /// Background / async reads only! Not for use in main thread / UI code.
    public let read: YapDatabaseConnection
    /// Background writes only! Never use this synchronously from the main thread!
    public let write: YapDatabaseConnection
    /// This is only to be used by the YapViewHandler for main thread reads only!
    public let longLivedRead: YapDatabaseConnection
}
```

This is exposed as a public member `connections` on `OTRDatabaseManager`, and the use of the connections exposed on the manager directly will be deprecated. It's also encouraged to store a `connections` reference in your class instead of reaching out to the singleton.

The logic behind this change is that we have been doing blocking reads on the read connection that was also sometimes used for some main thread UI operations, but also used for background reads in other modules. We now have distinctions for the two, and all one-off main thread reads should be done on the `ui` connection. These conditions are enforced during debug builds within the database itself (see `setupConnections` in `OTRDatabaseManager.m`).